### PR TITLE
Adds dct using vDSP_DCT for Vector{Float32}

### DIFF
--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -153,4 +153,21 @@ macro replaceBase(fs...)
     b
 end
 
+
+function plan_dct(n,k::Integer)
+    @assert isinteger(log2(n))
+    @assert 2≤k≤4
+    ccall(("vDSP_DCT_CreateSetup",libacc),Ptr{Void},(Ptr{Void},Cint,Cint),C_NULL,n,k)
+end
+
+function dct(r::Vector{Float32},plan)
+    n=length(r)
+    @assert isinteger(log2(n))
+    out=Array(Float32,n)
+    ccall(("vDSP_DCT_Execute",libacc),Void,(Ptr{Void},Ptr{Float32},Ptr{Float32}),plan,r,out)
+    out
+end
+
+dct(r::Vector{Float32},k::Integer)=dct(r,plan_dct(length(r),k))
+
 end # module

--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -129,6 +129,35 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
     end
 end
 
+
+function plan_dct(n,k::Integer)
+    @assert isinteger(Base.log2(n))
+    @assert 2≤k≤4
+    ccall(("vDSP_DCT_CreateSetup",libacc),Ptr{Void},(Ptr{Void},Cint,Cint),C_NULL,n,k)
+end
+
+
+
+
+function dct(r::Vector{Float32},plan)
+    n=length(r)
+    @assert isinteger(Base.log2(n))
+    out=Array(Float32,n)
+    ccall(("vDSP_DCT_Execute",libacc),Void,(Ptr{Void},Ptr{Float32},Ptr{Float32}),plan,r,out)
+    out
+end
+
+dct(r::Vector{Float32},k::Integer=2)=dct(r,plan_dct(length(r),k))
+
+
+
+if VERSION>=v"0.4.0-rc1"
+    tupletypelength(a)=length(a.parameters)
+else
+    tupletypelength(a)=length(a)
+end
+
+
 macro replaceBase(fs...)
     b = Expr(:block)
     for f in fs
@@ -140,7 +169,7 @@ macro replaceBase(fs...)
             fa = f
         end
         e = quote
-            if length(methods($f).defs.sig) == 1
+            if tupletypelength(methods($f).defs.sig) == 1
                 (Base.$f)(X::Array{Float64}) = ($fa)(X)
                 (Base.$f)(X::Array{Float32}) = ($fa)(X)
             else
@@ -154,20 +183,46 @@ macro replaceBase(fs...)
 end
 
 
-function plan_dct(n,k::Integer)
-    @assert isinteger(log2(n))
-    @assert 2≤k≤4
-    ccall(("vDSP_DCT_CreateSetup",libacc),Ptr{Void},(Ptr{Void},Cint,Cint),C_NULL,n,k)
-end
+# const     FFT_FORWARD         = +1
+# const     FFT_INVERSE         = -1
+# const     SIGNAL_STRIDE       = 1
+# 
+# typealias vDSP_Stride Clong
+# typealias vDSP_Length Culong
+# typealias FFTDirection Cint
+# 
+# immutable DSPDoubleSplitComplex
+#     realp::Ptr{Float64}
+#     imagp::Ptr{Float64}
+# end
+# 
+# DSPDoubleSplitComplex(realp::Vector{Float64},imagp::Vector{Float64})=DSPDoubleSplitComplex(pointer(realp),pointer(imagp))
+# 
+# 
+# function plan_fft(n,radix::Integer=2)
+#     @assert isinteger(log2(n))
+#     logn=round(Int,log2(n))
+#     ccall(("vDSP_create_fftsetupD",libacc),Ptr{Void},(Cuint,Cint),logn,radix)
+# end
+# 
+# function newfft(r::Vector{Complex128},plan)
+#     n=length(r)
+#     @assert isinteger(log2(n))
+#     logn=round(Int,log2(n))    
+#     
+#     realp,imagp=real(r),imag(r)         # keep references to avoid garbage collection
+#     vals=DSPDoubleSplitComplex(realp,imagp)
+#     retr,reti=Array(Float64,n),Array(Float64,n)        # keep references to avoid garbage collection
+#     ret=DSPDoubleSplitComplex(retr,reti)
+#     
+#     
+#     ccall(("vDSP_fft_zopD",libacc),Void,
+#           (Ptr{Void},DSPDoubleSplitComplex,vDSP_Stride,     DSPDoubleSplitComplex,vDSP_Stride,  vDSP_Length,FFTDirection),
+#            plan,     vals,                 SIGNAL_STRIDE,   ret,                  SIGNAL_STRIDE,logn,       FFT_FORWARD)
+#            
+#     retr+im*reti    
+# end
 
-function dct(r::Vector{Float32},plan)
-    n=length(r)
-    @assert isinteger(log2(n))
-    out=Array(Float32,n)
-    ccall(("vDSP_DCT_Execute",libacc),Void,(Ptr{Void},Ptr{Float32},Ptr{Float32}),plan,r,out)
-    out
-end
 
-dct(r::Vector{Float32},k::Integer)=dct(r,plan_dct(length(r),k))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,12 @@ facts("Hyperbolic") do
     end
 end
 
+facts("DCT") do
+    r=rand(Float32,2^16)
+    d1=dct(r)
+    d2=AppleAccelerate.dct(r)
+    @fact norm(d1[2]/d2[2]*d2[2:end]-d1[2:end])≤1000eps(Float32) --> true
+end
 
 facts("Misc.") do
     X = exp(10*randn(N))
@@ -117,7 +123,7 @@ facts("Extra") do
     @fact AppleAccelerate.pow(Y,X) => roughly(Y.^X)
     @fact AppleAccelerate.fdiv(X,Y) => roughly(X./Y)
 
-    @fact [AppleAccelerate.sincos(X)...] => roughly([sin(X),cos(X)])
+    @fact [AppleAccelerate.sincos(X)...] => roughly([sin(X);cos(X)])
     @fact AppleAccelerate.cosisin(X) => roughly(cos(X)+im*sin(X))
 end
 


### PR DESCRIPTION
This implements dct using Accelerate's vDSP_DCT routine.  As far as I know, there is only a single precision implementation.

I also fixed the unit tests.

I tried to implement the FFT as well (which supports double precision), but the currently commented out code causes a segment fault.  I'm not sure the correct way to pass in a pointer to a C struct

typedef struct DSPDoubleSplitComplex {
    double *realp;
    double *imagp;
} DSPDoubleSplitComplex;


 I tried creating what I thought would be the equivalent data structure to DSPDoubleSplitComplex*:

immutable DSPDoubleSplitComplex
     realp::Ptr{Float64}
     imagp::Ptr{Float64}
end

