### PR TITLE
Convolution + Corrrelation + Types for Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:
@@ -11,4 +10,4 @@ notifications:
 before_install:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
- - julia -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.clone("FactCheck"); Pkg.test("AppleAccelerate")'
+ - julia -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.test("AppleAccelerate")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,87 +10,91 @@ end
 srand(7)
 N = 1_000
 
-@testset "Rounding" begin
-    X = 100*randn(N)
-    @testset "Testing $f" for f in [:floor,:ceil,:trunc,:round]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X) ≈ fb(X)
+
+for T in (Float32, Float64)
+    @testset "Rounding::$T" begin
+        X::Array{T} = 100*randn(N)
+        @testset "Testing $f:$T" for f in [:floor,:ceil,:trunc,:round]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X) ≈ fb(X)
+        end
     end
 end
 
 
-@testset "Logarithmic" begin
-    X = exp(10*randn(N))
-    @testset "Testing $f" for f in [:log,:log2,:log10]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X) ≈ fb(X)
-    end
-
-    Y = expm1(10*randn(N))
-    @testset "Testing $f" for f in [:log1p]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(Y) ≈ fb(Y)
+for T in (Float32, Float64)
+    @testset "Logarithmic::$T" begin
+        X::Array{T} = exp(10*randn(N))
+        @testset "Testing $f::$T" for f in [:log,:log2,:log10, :log1p]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X) ≈ fb(X)
+        end
     end
 end
 
 
-@testset "Exponential" begin
-    X = 100*randn(N)
-    @testset "Testing $f" for f in [:exp,:exp2,:expm1]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X) ≈ fb(X)
+for T in (Float32, Float64)
+    @testset "Exponential::$T" begin
+        @testset "Testing $f::$T" for f in [:exp,:exp2,:expm1]
+            X::Array{T} = 10*randn(N)
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X) ≈ fb(X)
+        end
     end
 end
 
 
-@testset "Trigonometric" begin
-    X = 10*randn(N)
-    @testset "Testing $f" for f in [:sin,:sinpi,:cos,:cospi,:tan,:atan] # tanpi not defined in Base
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X) ≈ fb(X)
-    end
+for T in (Float32, Float64)
+    X::Array{T} = 10*randn(N)
+    @testset "Trigonometric::$T" begin
+        @testset "Testing $f::$T" for f in [:sin,:sinpi,:cos,:cospi,:tan,:atan] # tanpi not defined in Base
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X) ≈ fb(X)
+        end
 
-    Y = 10*randn(N)
-    @testset "Testing $f" for f in [:atan2]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X,Y) ≈ fb(X,Y)
-    end
+        Y::Array{T} = 10*randn(N)
+        @testset "Testing $f::$T" for f in [:atan2]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X,Y) ≈ fb(X,Y)
+        end
 
-    Z = 2*rand(N)-1
-    @testset "Testing $f" for f in [:asin,:acos]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(Z) ≈ fb(Z)
+        Z::Array{T} = 2*rand(N)-1
+        @testset "Testing $f::$T" for f in [:asin,:acos]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(Z) ≈ fb(Z)
+        end
     end
 end
 
 
-@testset "Hyperbolic" begin
-    X = 10*randn(N)
-    @testset "Testing $f" for f in [:sinh,:cosh,:tanh,:asinh]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X) ≈ fb(X)
-    end
+for T in (Float32, Float64)
+    @testset "Hyperbolic::$T" begin
+        X = 10*randn(N)
+        @testset "Testing $f::$T" for f in [:sinh,:cosh,:tanh,:asinh]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X) ≈ fb(X)
+        end
 
-    Y = exp(10*randn(N))+1
-    @testset "Testing $f" for f in [:acosh]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(Y) ≈ fb(Y)
-    end
+        Y = exp(10*randn(N))+1
+        @testset "Testing $f::$T" for f in [:acosh]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(Y) ≈ fb(Y)
+        end
 
-    Z = 2*rand(N)-1
-    @testset "Testing $f" for f in [:atanh]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(Z) ≈ fb(Z)
+        Z = 2*rand(N)-1
+        @testset "Testing $f::$T" for f in [:atanh]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(Z) ≈ fb(Z)
+        end
     end
 end
 
@@ -103,56 +107,81 @@ end
 end
 
 
-@testset "Misc" begin
-    X = exp(10*randn(N))
-    @testset "Testing $f" for f in [:sqrt]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X) ≈ fb(X)
+for T in (Float32, Float64)
+    @testset "Convolution & Correlation::$T" begin
+        X::Array{T} = randn(N)
+        Y::Array{T} = randn(N)
+        @testset "Testing $f::$T" for f in [:conv, :xcorr]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fb(X, Y) ≈ fa(X, Y)
+        end
+
+        @testset "Testing $f::$T" for f in [:xcorr]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fb(X, copy(X)) ≈ fa(X)
+        end
     end
-
-    Y = 10*randn(N)
-    @testset "Testing $f" for f in [:exponent, :abs]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(Y) ≈ fb(Y)
-    end
-
-    Z = 10*randn(N)
-    @testset "Testing $f" for f in [:copysign]
-        @eval fb = $f
-        @eval fa = AppleAccelerate.$f
-        @test fa(X,Y) ≈ fb(X,Y)
-    end
-
-    @test AppleAccelerate.rem(X,Y) == [rem(X[i], Y[i]) for i=1:length(X)]
-
 end
 
 
-@testset "Extra" begin
-    X = randn(N)
-    Y = abs(randn(N))
+for T in (Float32, Float64)
+    @testset "Misc::$T" begin
+        X::Array{T} = exp(10*randn(N))
+        @testset "Testing $f::$T" for f in [:sqrt]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X) ≈ fb(X)
+        end
 
-    @test AppleAccelerate.rec(X) ≈ 1./X
-    @test AppleAccelerate.rsqrt(Y) ≈ 1./sqrt(Y)
-    @test AppleAccelerate.pow(Y,X) ≈ Y.^X
-    @test AppleAccelerate.fdiv(X,Y) ≈ X./Y
+        Y::Array{T} = 10*randn(N)
+        @testset "Testing $f::$T" for f in [:exponent, :abs]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(Y) ≈ fb(Y)
+        end
 
-    @test AppleAccelerate.sincos(X)[1] ≈ sin(X)
-    @test AppleAccelerate.sincos(X)[2] ≈ cos(X)
-    @test AppleAccelerate.cis(X) ≈ cis(X)
+        Z::Array{T} = 10*randn(N)
+        @testset "Testing $f::$T" for f in [:copysign]
+            @eval fb = $f
+            @eval fa = AppleAccelerate.$f
+            @test fa(X,Y) ≈ fb(X,Y)
+        end
 
+        @test AppleAccelerate.rem(X,Y) == [rem(X[i], Y[i]) for i=1:length(X)]
+
+    end
 end
 
 
-@testset "Replace Base" begin
-    X = randn(N)
-    Y = abs(randn(N))
+for T in (Float32, Float64)
+    @testset "Extra::$T" begin
+        X::Array{T} = randn(N)
+        Y::Array{T} = abs(randn(N))
 
-    AppleAccelerate.@replaceBase(sin, atan2, ./)
-    @test sin(X) == AppleAccelerate.sin(X)
-    @test atan2(X, Y) == AppleAccelerate.atan2(X, Y)
-    @test X ./ Y  == AppleAccelerate.fdiv(X, Y)
+        @test AppleAccelerate.rec(X) ≈ 1./X
+        @test AppleAccelerate.rsqrt(Y) ≈ 1./sqrt(Y)
+        @test AppleAccelerate.pow(Y,X) ≈ Y.^X
+        @test AppleAccelerate.fdiv(X,Y) ≈ X./Y
 
+        @test AppleAccelerate.sincos(X)[1] ≈ sin(X)
+        @test AppleAccelerate.sincos(X)[2] ≈ cos(X)
+        @test AppleAccelerate.cis(X) ≈ cis(X)
+
+    end
+end
+
+
+for T in (Float32, Float64)
+    @testset "Replace Base::$T" begin
+        X::Array{T} = randn(N)
+        Y::Array{T} = abs(randn(N))
+
+        AppleAccelerate.@replaceBase(sin, atan2, ./)
+        @test Base.sin(X) == AppleAccelerate.sin(X)
+        @test Base.atan2(X, Y) == AppleAccelerate.atan2(X, Y)
+        @test X ./ Y  == AppleAccelerate.fdiv(X, Y)
+
+    end
 end


### PR DESCRIPTION
Another PR! This one contains the following:

1. `conv`: Convolution for Float64 and Float32 (initial profiling indicates that AppleAccelerate.conv is 23 times faster than `Base.conv`, and allocates 6 times less memory, for two arrays of length 100)
2. `xcorr`: Cross-correlation and auto-correlation for Float32 and Float64
3. Tests for the above functions for both types. I also noticed that the existing test suite did not contain testing for Float32. I made further enhancements to the existing tests so that they explicitly run on Float32 and Float64 and that this information is included in any error messages that are produced. 

**Travis Results**
2. v0.4: All tests pass.
3. v0.5: The `sin` test in `@replaceBase` (the start of all of this testing rewrite) still fails on Travis; *all* other tests pass. I've run it on three separate machines on both OS X and Ubuntu and the test always passes for me. At this point, I'm at a loss as for why it is failing in Travis but not locally. If you have any advice here, it would be most appreciated. 

Updated the .travis.yml per tkelman's suggestion (this is the cause of the merge). 