### PR TITLE
fix replaceBase macro in 0.5

### DIFF
--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -204,14 +204,22 @@ macro replaceBase(fs...)
         else
             fa = f
         end
-        e = quote
-            if tupletypelength(methods($f).defs.sig) == 1
-                (Base.$f)(X::Array{Float64, 1}) = ($fa)(X)
-                (Base.$f)(X::Array{Float32, 1}) = ($fa)(X)
-            else
-                (Base.$f)(X::Array{Float64, 1}, Y::Array{Float64, 1}) = ($fa)(X,Y)
-                (Base.$f)(X::Array{Float32, 1}, Y::Array{Float32, 1}) = ($fa)(X,Y)
+        if fa in (:ceil,:floor,:sqrt,:rsqrt,:rec,
+                  :exp,:exp2,:expm1,:log,:log1p,:log2,:log10,
+                  :sin,:sinpi,:cos,:cospi,:tan,:tanpi,:asin,:acos,:atan,
+                  :sinh,:cosh,:tanh,:asinh,:acosh,:atanh,
+                  :trunc,:round,:exponent,:abs,:sincos,:cis)
+            e = quote
+                (Base.$f)(X::Array{Float64}) = ($fa)(X)
+                (Base.$f)(X::Array{Float32}) = ($fa)(X)
             end
+        elseif fa in (:copysign,:atan2,:pow,:rem,:fdiv)
+            e = quote
+                (Base.$f)(X::Array{Float64},Y::Array{Float64}) = ($fa)(X,Y)
+                (Base.$f)(X::Array{Float32},Y::Array{Float32}) = ($fa)(X,Y)
+            end
+        else
+            error("Function $f not defined by Accelerate")
         end
         push!(b.args,e)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,15 +173,13 @@ for T in (Float32, Float64)
 end
 
 
-for T in (Float32, Float64)
-    @testset "Replace Base::$T" begin
-        X::Array{T} = randn(N)
-        Y::Array{T} = abs(randn(N))
+AppleAccelerate.@replaceBase(sin, atan2, ./)
 
-        AppleAccelerate.@replaceBase(sin, atan2, ./)
-        @test Base.sin(X) == AppleAccelerate.sin(X)
-        @test Base.atan2(X, Y) == AppleAccelerate.atan2(X, Y)
-        @test X ./ Y  == AppleAccelerate.fdiv(X, Y)
+@testset "Replace Base::$T" for T in (Float32, Float64)
+    X::Array{T} = randn(N)
+    Y::Array{T} = abs(randn(N))
 
-    end
+    @test Base.sin(X) == AppleAccelerate.sin(X)
+    @test Base.atan2(X, Y) == AppleAccelerate.atan2(X, Y)
+    @test X ./ Y  == AppleAccelerate.fdiv(X, Y)
 end


### PR DESCRIPTION
This should hopefully fix the issues with `@replaceBase` that was causing the tests on 0.5 to fail.