### PR TITLE
Initial Implementation of Biquads

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 BaseTestNext
+DSP

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,15 +129,15 @@ for T in (Float32,  Float64)
     end
 end
 
-for T in (Float32, Float64)
+for T in (Float64, )
     @testset "Biquadratic Flitering::$T" begin
         @testset "Single Section::$T" begin
             X::Vector{T} = randn(10)
             d::Vector{T} = zeros(4)
-            c::Vector{T} = [0.5, 0.5, 0.5, 0.5, 0.5]
+            c::Vector{T} = [x%0.5 for x in randn(5)]
             fdsp = DSP.Biquad(c[1], c[2], c[3], c[4], c[5])
-            fa = AppleAccelerate.createbiquad(c, 1)
-            @test filt(fdsp, X) ≈ AppleAccelerate.biquad(X, d, length(X), fa)
+            fa = AppleAccelerate.biquadcreate(c, 1)
+            @test DSP.filt(fdsp, X) ≈ AppleAccelerate.biquad(X, d, length(X), fa)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AppleAccelerate
+using DSP
 
 if VERSION >= v"0.5-"
     using Base.Test
@@ -112,8 +113,8 @@ end
 
 for T in (Float32,  Float64)
     @testset "Convolution & Correlation::$T" begin
-        X::Array{T} = randn(N)
-        Y::Array{T} = randn(N)
+        X::Vector{T} = randn(N)
+        Y::Vector{T} = randn(N)
         @testset "Testing $f::$T" for f in [:conv, :xcorr]
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
@@ -124,6 +125,19 @@ for T in (Float32,  Float64)
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
             @test fb(X, copy(X)) ≈ fa(X)
+        end
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "Biquadratic Flitering::$T" begin
+        @testset "Single Section::$T" begin
+            X::Vector{T} = randn(10)
+            d::Vector{T} = zeros(4)
+            c::Vector{T} = [0.5, 0.5, 0.5, 0.5, 0.5]
+            fdsp = DSP.Biquad(c[1], c[2], c[3], c[4], c[5])
+            fa = AppleAccelerate.createbiquad(c, 1)
+            @test filt(fdsp, X) ≈ AppleAccelerate.biquad(X, d, length(X), fa)
         end
     end
 end


### PR DESCRIPTION
This PR contains an initial implementation of Accelerate's single channel biquad functions. 

There are currently no tests in `runtest.jl` for these functions because I wanted to get thoughts on the best way to test functions that don't have equivalents in Base; I have tested them manually against Matlab so I know that they are functioning correctly. I've laid out the two testing options that I'm aware of: 

1) If we include [DSP.jl](https://github.com/JuliaDSP/DSP.jl), we can compare our results on random vectors to the pure Julia equivalents included in DSP.jl. This obviously makes our testing dependent upon the state of DSP.jl, but may be the cleaner solution
2) ~~I can hard-code in some representative tests into `runtest.jl` so that we don't have any test dependencies; this will obviously limit the size and variability of the test cases.~~
3) ~~Write pure Julia versions of the Accelerate biquad functions to test against.
https://github.com/JuliaLang/AppleAccelerate.jl~~

I'm more in the favor of option 1 or 3, but wanted to run it by anyone who was interested. 

@simonbyrne What is your preference? 