### PR TITLE
Added check to verify existence of Accelerate framework

### DIFF
--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -3,6 +3,10 @@ module AppleAccelerate
 
 const libacc = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
 
+if !isfile(libacc)
+    error("Accelerate framework not found at $(libacc)")
+end
+
 include("Array.jl")
 include("DSP.jl")
 include("Util.jl")


### PR DESCRIPTION
I thought it might be wise to verify the location of the Accelerate framework before installation; just to be safe. 