### PR TITLE
Bug in OPS fixed

### DIFF
--- a/src/Util.jl
+++ b/src/Util.jl
@@ -7,8 +7,8 @@ tupletypelength(a)=length(a.parameters)
 
 const OPS = Dict{Symbol,Tuple{Symbol, Symbol, Symbol}}(:+ => (:vadd, :vsadd, :vsadd),
 :- => (:vsub, :vssub, :svsub),
-:* => (:vadd, :vsmul, :vsmul),
-:/ => (:vadd, :vsdiv, :vsdiv),)
+:* => (:vmul, :vsmul, :vsmul),
+:/ => (:vdiv, :vsdiv, :vsdiv),)
 
 macro replaceBase(fs...)
     b = Expr(:block)


### PR DESCRIPTION
A call to `AppleAccelerate.@replaceBase (*, /)` produces wrong results as a result of a bug in OPS, now fixed. For example

```julia-repl
julia> using AppleAccelerate

julia> AppleAccelerate.@replaceBase (/)

julia> [6.0, 4.0, 2.0] / [3.0, 1.0, 4.0]
3-element Vector{Float64}:
 9.0
 5.0
 6.0
```

This is now fixed.