### PR TITLE
Align FFT API with AbstractFFTs conventions and add AbstractFFTs extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,20 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+[weakdeps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+
+[extensions]
+AppleAccelerateAbstractFFTsExt = "AbstractFFTs"
+
 [compat]
+AbstractFFTs = "1.5"
 DSP = "0.8.4"
 FFTW = "1.10"
 julia = "1.10"
 
 [extras]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -28,4 +36,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dates", "Distributed", "FFTW", "Printf", "Random", "REPL", "Sockets", "SparseArrays", "SpecialFunctions", "DSP", "Statistics", "Test"]
+test = ["AbstractFFTs", "Dates", "Distributed", "FFTW", "Printf", "Random", "REPL", "Sockets", "SparseArrays", "SpecialFunctions", "DSP", "Statistics", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 AppleAccelerate = "13e28ba4-7ad8-5781-acae-3021b1ed3924"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -16,7 +16,7 @@
 
 ## DSP & FFT
 
-- `plan_fft`, `fft`, `destroy_fftsetup` — FFT (Float32 and Float64)
+- `fft`, `ifft`, `bfft`, `plan_fft` — FFT (Float32 and Float64, 1D and 2D)
 - [`AppleAccelerate.plan_dct`](@ref), [`AppleAccelerate.dct`](@ref) — DCT (Float32 only)
 - `conv`, `conv!` — Convolution
 - `xcorr`, `xcorr!` — Cross-correlation

--- a/docs/src/dsp.md
+++ b/docs/src/dsp.md
@@ -3,42 +3,67 @@
 AppleAccelerate wraps vDSP functions for signal processing, including convolution, correlation, filtering, windowing, DCT, and FFT.
 
 ```@setup dsp
-using AppleAccelerate
+using AppleAccelerate, AbstractFFTs
 ```
 
 ## FFT
 
-```@example dsp
-# Create an FFT plan (reusable for same-size transforms)
-setup = AppleAccelerate.plan_fft(1024, Float64)
+The FFT API follows the same naming conventions as [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl): `fft`, `ifft`, `bfft`, and `plan_fft`. Both 1D vectors and 2D matrices are supported with `ComplexF64` and `ComplexF32` inputs. All dimensions must be powers of 2.
 
-# Forward FFT
+```@example dsp
 x = randn(ComplexF64, 1024)
-X = AppleAccelerate.fft(x, setup)
 
-# Inverse FFT
-x_recovered = AppleAccelerate.fft(X, setup, AppleAccelerate.FFT_INVERSE)
+# Forward FFT (auto-creates plan)
+X = AppleAccelerate.fft(x)
+
+# Normalized inverse FFT
+x_recovered = AppleAccelerate.ifft(X)
+
+# Unnormalized inverse (backward) FFT
+X_back = AppleAccelerate.bfft(X)
+
+# Reusable plan for repeated transforms of the same size
+setup = AppleAccelerate.plan_fft(x)
+X = AppleAccelerate.fft(x, setup)
+x_recovered = AppleAccelerate.ifft(X, setup)
 nothing # hide
 ```
 
-Both `ComplexF64` and `ComplexF32` inputs are supported. Input length must be a power of 2.
-
-## 2D FFT
+2D FFT works the same way — `fft` dispatches on the input shape:
 
 ```@example dsp
-# Create an FFT plan (must accommodate the largest dimension)
-setup = AppleAccelerate.plan_fft(32, Float64)
-
-# Forward 2D FFT
-x = randn(ComplexF64, 16, 32)
-X = AppleAccelerate.fft2d(x, setup)
-
-# Inverse 2D FFT (unnormalized — divide by nrows*ncols to recover original)
-x_recovered = AppleAccelerate.fft2d(X, setup, AppleAccelerate.FFT_INVERSE) ./ (16 * 32)
+x2 = randn(ComplexF64, 16, 32)
+X2 = AppleAccelerate.fft(x2)
+x2_recovered = AppleAccelerate.ifft(X2)
 nothing # hide
 ```
 
-Both dimensions must be powers of 2. The `FFTSetup` must be created with `n >= max(nrows, ncols)`.
+### AbstractFFTs Integration
+
+AppleAccelerate provides a package extension for [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl), allowing you to use the standard Julia FFT interface backed by Apple's vDSP library. Load both packages to activate the extension:
+
+```@example dsp
+# 1D FFT
+x = randn(ComplexF64, 1024)
+X = fft(x)
+x_recovered = ifft(X)
+
+# 2D FFT
+x2 = randn(ComplexF64, 16, 32)
+X2 = fft(x2)
+x2_recovered = ifft(X2)
+
+# Plan-based API (works for both 1D and 2D)
+p = plan_fft(x)
+X = p * x
+x_recovered = p \ X
+nothing # hide
+```
+
+The extension supports `fft`, `ifft`, `bfft`, `plan_fft`, `plan_ifft`, `plan_bfft`, plan inversion via `inv(plan)`, and `mul!` for both 1D vectors and 2D matrices. Input must be `Vector{Complex{T}}` or `Matrix{Complex{T}}` with power-of-2 dimensions.
+
+!!! note
+    In-place plans (`plan_fft!`, `plan_bfft!`) and real FFTs (`rfft`, `irfft`) are not supported since vDSP only provides out-of-place complex FFTs. 3D and higher-dimensional arrays are not supported by vDSP and will fall through to FFTW if available.
 
 ## DCT (Discrete Cosine Transform)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,8 +56,8 @@ nothing # hide
 using AppleAccelerate
 
 x = randn(ComplexF64, 1024)
-setup = AppleAccelerate.plan_fft(length(x))
-y = AppleAccelerate.fft(x, setup)
+X = AppleAccelerate.fft(x)
+x_recovered = AppleAccelerate.ifft(X)
 nothing # hide
 ```
 

--- a/ext/AppleAccelerateAbstractFFTsExt.jl
+++ b/ext/AppleAccelerateAbstractFFTsExt.jl
@@ -1,0 +1,142 @@
+module AppleAccelerateAbstractFFTsExt
+
+@static if Sys.isapple()
+
+using AbstractFFTs
+using AbstractFFTs: Plan, ScaledPlan
+using LinearAlgebra
+using AppleAccelerate
+using AppleAccelerate: FFTSetup
+
+# Forward FFT plan wrapping vDSP
+mutable struct VDSPFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
+    setup::FFTSetup{T}
+    sz::NTuple{N,Int}
+    region::G
+    pinv::Plan{Complex{T}}
+    function VDSPFFTPlan{T}(setup::FFTSetup{T}, sz::NTuple{N,Int}, region::G) where {T,N,G}
+        new{T,N,G}(setup, sz, region)
+    end
+end
+
+# Backward (unnormalized inverse) FFT plan wrapping vDSP
+mutable struct VDSPBFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
+    setup::FFTSetup{T}
+    sz::NTuple{N,Int}
+    region::G
+    pinv::Plan{Complex{T}}
+    function VDSPBFFTPlan{T}(setup::FFTSetup{T}, sz::NTuple{N,Int}, region::G) where {T,N,G}
+        new{T,N,G}(setup, sz, region)
+    end
+end
+
+Base.size(p::VDSPFFTPlan) = p.sz
+Base.size(p::VDSPBFFTPlan) = p.sz
+
+AbstractFFTs.AdjointStyle(::VDSPFFTPlan) = AbstractFFTs.FFTAdjointStyle()
+AbstractFFTs.AdjointStyle(::VDSPBFFTPlan) = AbstractFFTs.FFTAdjointStyle()
+
+function _check_vdsp_fft(x::AbstractVector)
+    n = length(x)
+    n > 0 || throw(ArgumentError("input array must be non-empty"))
+    ispow2(n) || throw(ArgumentError("vDSP FFT requires power-of-2 length, got $n"))
+    return nothing
+end
+
+function _check_vdsp_fft(x::AbstractMatrix)
+    nrows, ncols = size(x)
+    nrows > 0 && ncols > 0 || throw(ArgumentError("input matrix must be non-empty"))
+    ispow2(nrows) || throw(ArgumentError("vDSP 2D FFT requires power-of-2 row count, got $nrows"))
+    ispow2(ncols) || throw(ArgumentError("vDSP 2D FFT requires power-of-2 column count, got $ncols"))
+    return nothing
+end
+
+# 1D plans
+function AbstractFFTs.plan_fft(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
+    _check_vdsp_fft(x)
+    setup = FFTSetup{T}(length(x))
+    VDSPFFTPlan{T}(setup, size(x), region)
+end
+
+function AbstractFFTs.plan_bfft(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
+    _check_vdsp_fft(x)
+    setup = FFTSetup{T}(length(x))
+    VDSPBFFTPlan{T}(setup, size(x), region)
+end
+
+# 2D plans
+function AbstractFFTs.plan_fft(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
+    _check_vdsp_fft(x)
+    nrows, ncols = size(x)
+    setup = FFTSetup{T}(max(nrows, ncols))
+    VDSPFFTPlan{T}(setup, size(x), region)
+end
+
+function AbstractFFTs.plan_bfft(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
+    _check_vdsp_fft(x)
+    nrows, ncols = size(x)
+    setup = FFTSetup{T}(max(nrows, ncols))
+    VDSPBFFTPlan{T}(setup, size(x), region)
+end
+
+# 1D execution
+function Base.:*(p::VDSPFFTPlan{T,1}, x::AbstractVector) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.fft(convert(Vector{Complex{T}}, x), p.setup)
+end
+
+function Base.:*(p::VDSPBFFTPlan{T,1}, x::AbstractVector) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.bfft(convert(Vector{Complex{T}}, x), p.setup)
+end
+
+# 2D execution
+function Base.:*(p::VDSPFFTPlan{T,2}, x::AbstractMatrix) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.fft(convert(Matrix{Complex{T}}, x), p.setup)
+end
+
+function Base.:*(p::VDSPBFFTPlan{T,2}, x::AbstractMatrix) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.bfft(convert(Matrix{Complex{T}}, x), p.setup)
+end
+
+# 1D mul!
+function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, AppleAccelerate.fft(convert(Vector{Complex{T}}, x), p.setup))
+end
+
+function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPBFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, AppleAccelerate.bfft(convert(Vector{Complex{T}}, x), p.setup))
+end
+
+# 2D mul!
+function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, AppleAccelerate.fft(convert(Matrix{Complex{T}}, x), p.setup))
+end
+
+function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPBFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, AppleAccelerate.bfft(convert(Matrix{Complex{T}}, x), p.setup))
+end
+
+function AbstractFFTs.plan_inv(p::VDSPFFTPlan{T}) where {T}
+    bplan = VDSPBFFTPlan{T}(p.setup, p.sz, p.region)
+    N = AbstractFFTs.normalization(Complex{T}, p.sz, p.region)
+    bplan.pinv = ScaledPlan(p, N)
+    ScaledPlan(bplan, N)
+end
+
+function AbstractFFTs.plan_inv(p::VDSPBFFTPlan{T}) where {T}
+    fplan = VDSPFFTPlan{T}(p.setup, p.sz, p.region)
+    N = AbstractFFTs.normalization(Complex{T}, p.sz, p.region)
+    fplan.pinv = ScaledPlan(p, N)
+    ScaledPlan(fplan, N)
+end
+
+end # @static if Sys.isapple()
+
+end # module

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -416,6 +416,15 @@ function plan_fft(n::Integer, ::Type{T}=Float64, radix::Integer = 2) where T <: 
     FFTSetup{T}(n, radix)
 end
 
+function plan_fft(x::Vector{Complex{T}}) where T <: Union{Float32, Float64}
+    FFTSetup{T}(length(x))
+end
+
+function plan_fft(x::Matrix{Complex{T}}) where T <: Union{Float32, Float64}
+    nrows, ncols = size(x)
+    FFTSetup{T}(max(nrows, ncols))
+end
+
 function destroy_fftsetup(setup::FFTSetup{Float64})
     ccall(("vDSP_destroy_fftsetupD", libacc), Cvoid, (Ptr{Cvoid},), setup.plan)
 end
@@ -424,7 +433,9 @@ function destroy_fftsetup(setup::FFTSetup{Float32})
     ccall(("vDSP_destroy_fftsetup", libacc), Cvoid, (Ptr{Cvoid},), setup.plan)
 end
 
-function fft(r::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int=FFT_FORWARD)
+# --- Internal 1D FFT (direction-based) ---
+
+function _fft1d(r::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
     n = length(r)
     @assert ispow2(n) "length of input must be a power of 2"
     logn = trailing_zeros(n)
@@ -446,7 +457,7 @@ function fft(r::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int=FFT
     return complex.(retr, reti)
 end
 
-function fft(r::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int=FFT_FORWARD)
+function _fft1d(r::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int)
     n = length(r)
     @assert ispow2(n) "length of input must be a power of 2"
     logn = trailing_zeros(n)
@@ -468,14 +479,9 @@ function fft(r::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int=FFT
     return complex.(retr, reti)
 end
 
-"""
-    fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction=FFT_FORWARD)
+# --- Internal 2D FFT (direction-based) ---
 
-Compute the 2D complex FFT of matrix `r` using the given `FFTSetup`.
-Both dimensions must be powers of 2. The `setup` must have been created with
-`n >= max(size(r)...)`.
-"""
-function fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int=FFT_FORWARD)
+function _fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
     nrows, ncols = size(r)
     @assert ispow2(nrows) && ispow2(ncols) "dimensions must be powers of 2"
     log2nr = trailing_zeros(nrows)
@@ -499,14 +505,7 @@ function fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int=F
     return complex.(retr, reti)
 end
 
-"""
-    fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction=FFT_FORWARD)
-
-Compute the 2D complex FFT of matrix `r` using the given `FFTSetup`.
-Both dimensions must be powers of 2. The `setup` must have been created with
-`n >= max(size(r)...)`.
-"""
-function fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int=FFT_FORWARD)
+function _fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int)
     nrows, ncols = size(r)
     @assert ispow2(nrows) && ispow2(ncols) "dimensions must be powers of 2"
     log2nr = trailing_zeros(nrows)
@@ -529,3 +528,24 @@ function fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int=F
 
     return complex.(retr, reti)
 end
+
+# --- Public API: fft (forward FFT) ---
+
+fft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d(x, setup, FFT_FORWARD)
+fft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d(x, setup, FFT_FORWARD)
+fft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = fft(x, plan_fft(x))
+fft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = fft(x, plan_fft(x))
+
+# --- Public API: bfft (backward/unnormalized inverse FFT) ---
+
+bfft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d(x, setup, FFT_INVERSE)
+bfft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d(x, setup, FFT_INVERSE)
+bfft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft(x, plan_fft(x))
+bfft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft(x, plan_fft(x))
+
+# --- Public API: ifft (normalized inverse FFT) ---
+
+ifft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = bfft(x, setup) ./ length(x)
+ifft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = bfft(x, setup) ./ length(x)
+ifft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft(x, plan_fft(x))
+ifft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft(x, plan_fft(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using LinearAlgebra
 using AppleAccelerate
+using AbstractFFTs
 using DSP, FFTW, Test, Random, Statistics
 
 if !Sys.isapple()
@@ -176,122 +177,254 @@ end
     @test norm(d1[2]/d2[2]*d2[2:end]-d1[2:end])≤1000eps(Float32)
 end
 
-@testset "FFT::Float64" begin
+@testset "fft::Float64" begin
     for n in (16, 256, 1024)
         r = randn(ComplexF64, n)
-        plan = AppleAccelerate.plan_fft(n, Float64)
-        result = AppleAccelerate.fft(r, plan)
-        expected = FFTW.fft(r)
-        @test result ≈ expected
+        @test AppleAccelerate.fft(r) ≈ FFTW.fft(r)
+        # With explicit plan
+        setup = AppleAccelerate.plan_fft(r)
+        @test AppleAccelerate.fft(r, setup) ≈ FFTW.fft(r)
     end
 end
 
-@testset "FFT::Float32" begin
+@testset "fft::Float32" begin
     for n in (16, 256, 1024)
         r = randn(ComplexF32, n)
-        plan = AppleAccelerate.plan_fft(n, Float32)
-        result = AppleAccelerate.fft(r, plan)
-        expected = FFTW.fft(r)
-        @test result ≈ expected rtol=sqrt(eps(Float32))
+        @test AppleAccelerate.fft(r) ≈ FFTW.fft(r) rtol=sqrt(eps(Float32))
     end
 end
 
-@testset "FFT known values" begin
+@testset "fft known values" begin
     # DFT of unit impulse is all ones
-    plan4 = AppleAccelerate.plan_fft(4, Float64)
-    @test AppleAccelerate.fft(ComplexF64[1, 0, 0, 0], plan4) ≈ ComplexF64[1, 1, 1, 1]
+    @test AppleAccelerate.fft(ComplexF64[1, 0, 0, 0]) ≈ ComplexF64[1, 1, 1, 1]
     # DFT of constant is scaled impulse
-    @test AppleAccelerate.fft(ComplexF64[1, 1, 1, 1], plan4) ≈ ComplexF64[4, 0, 0, 0]
+    @test AppleAccelerate.fft(ComplexF64[1, 1, 1, 1]) ≈ ComplexF64[4, 0, 0, 0]
     # DFT of single frequency: e^{2πi k/N} for k=0..N-1 has DFT = N δ_{1}
     r = [exp(2π * im * k / 4) for k in 0:3]
-    result = AppleAccelerate.fft(ComplexF64.(r), plan4)
+    result = AppleAccelerate.fft(ComplexF64.(r))
     @test abs(result[2]) ≈ 4.0 atol=1e-12
     @test abs(result[1]) < 1e-12
     @test abs(result[3]) < 1e-12
     @test abs(result[4]) < 1e-12
 
     # Parseval's theorem: sum(|x|^2) == sum(|X|^2) / N
-    plan256 = AppleAccelerate.plan_fft(256, Float64)
     x = randn(ComplexF64, 256)
-    X = AppleAccelerate.fft(x, plan256)
+    X = AppleAccelerate.fft(x)
     @test sum(abs2, x) ≈ sum(abs2, X) / 256
 
     # Linearity: FFT(a*x + b*y) == a*FFT(x) + b*FFT(y)
-    plan128 = AppleAccelerate.plan_fft(128, Float64)
     x1 = randn(ComplexF64, 128)
     x2 = randn(ComplexF64, 128)
     a, b = 3.0 + 1.0im, -2.0 + 0.5im
-    @test AppleAccelerate.fft(ComplexF64.(a .* x1 .+ b .* x2), plan128) ≈
-          a .* AppleAccelerate.fft(x1, plan128) .+ b .* AppleAccelerate.fft(x2, plan128)
+    @test AppleAccelerate.fft(ComplexF64.(a .* x1 .+ b .* x2)) ≈
+          a .* AppleAccelerate.fft(x1) .+ b .* AppleAccelerate.fft(x2)
 
     # Circular shift property: left shift by m multiplies FFT by e^{+2πi m k/N}
-    plan64 = AppleAccelerate.plan_fft(64, Float64)
     x = randn(ComplexF64, 64)
     m = 7
     x_shifted = circshift(x, -m)
-    X = AppleAccelerate.fft(x, plan64)
-    X_shifted = AppleAccelerate.fft(x_shifted, plan64)
+    X = AppleAccelerate.fft(x)
+    X_shifted = AppleAccelerate.fft(x_shifted)
     phase = [exp(2π * im * m * k / 64) for k in 0:63]
     @test X_shifted ≈ X .* phase
 end
 
-@testset "IFFT roundtrip" begin
+@testset "bfft and ifft roundtrip" begin
     for T in (ComplexF64, ComplexF32)
         F = real(T)
         @testset "$T" begin
             for n in (16, 256, 1024)
                 r = randn(T, n)
-                plan = AppleAccelerate.plan_fft(n, F)
-                fwd = AppleAccelerate.fft(r, plan, AppleAccelerate.FFT_FORWARD)
-                inv = AppleAccelerate.fft(fwd, plan, AppleAccelerate.FFT_INVERSE)
-                # vDSP inverse FFT does not divide by n, so we do it ourselves
+                fwd = AppleAccelerate.fft(r)
+                # bfft is unnormalized inverse
                 if F == Float64
-                    @test inv ./ n ≈ r
+                    @test AppleAccelerate.bfft(fwd) ./ n ≈ r
                 else
-                    @test inv ./ n ≈ r rtol=sqrt(eps(Float32))
+                    @test AppleAccelerate.bfft(fwd) ./ n ≈ r rtol=sqrt(eps(Float32))
+                end
+                # ifft is normalized inverse
+                if F == Float64
+                    @test AppleAccelerate.ifft(fwd) ≈ r
+                else
+                    @test AppleAccelerate.ifft(fwd) ≈ r rtol=sqrt(eps(Float32))
                 end
             end
         end
     end
 end
 
-@testset "FFT2D::Float64" begin
+@testset "fft 2D::Float64" begin
     for (nr, nc) in ((4, 4), (8, 16), (16, 8), (32, 32))
         r = randn(ComplexF64, nr, nc)
-        plan = AppleAccelerate.plan_fft(max(nr, nc), Float64)
-        result = AppleAccelerate.fft2d(r, plan)
-        expected = FFTW.fft(r)
-        @test result ≈ expected
+        @test AppleAccelerate.fft(r) ≈ FFTW.fft(r)
+        # With explicit plan
+        setup = AppleAccelerate.plan_fft(r)
+        @test AppleAccelerate.fft(r, setup) ≈ FFTW.fft(r)
     end
 end
 
-@testset "FFT2D::Float32" begin
+@testset "fft 2D::Float32" begin
     for (nr, nc) in ((4, 4), (8, 16), (16, 8), (32, 32))
         r = randn(ComplexF32, nr, nc)
-        plan = AppleAccelerate.plan_fft(max(nr, nc), Float32)
-        result = AppleAccelerate.fft2d(r, plan)
-        expected = FFTW.fft(r)
-        @test result ≈ expected rtol=sqrt(eps(Float32))
+        @test AppleAccelerate.fft(r) ≈ FFTW.fft(r) rtol=sqrt(eps(Float32))
     end
 end
 
-@testset "IFFT2D roundtrip" begin
+@testset "bfft and ifft 2D roundtrip" begin
     for T in (ComplexF64, ComplexF32)
         F = real(T)
         @testset "$T" begin
             for (nr, nc) in ((4, 8), (16, 16))
                 r = randn(T, nr, nc)
-                plan = AppleAccelerate.plan_fft(max(nr, nc), F)
-                fwd = AppleAccelerate.fft2d(r, plan, AppleAccelerate.FFT_FORWARD)
-                inv_result = AppleAccelerate.fft2d(fwd, plan, AppleAccelerate.FFT_INVERSE)
+                fwd = AppleAccelerate.fft(r)
                 ntotal = nr * nc
                 if F == Float64
-                    @test inv_result ./ ntotal ≈ r
+                    @test AppleAccelerate.bfft(fwd) ./ ntotal ≈ r
+                    @test AppleAccelerate.ifft(fwd) ≈ r
                 else
-                    @test inv_result ./ ntotal ≈ r rtol=sqrt(eps(Float32))
+                    @test AppleAccelerate.bfft(fwd) ./ ntotal ≈ r rtol=sqrt(eps(Float32))
+                    @test AppleAccelerate.ifft(fwd) ≈ r rtol=sqrt(eps(Float32))
                 end
             end
         end
+    end
+end
+
+@testset "AbstractFFTs extension" begin
+    @testset "Forward FFT matches FFTW" begin
+        for T in (ComplexF64, ComplexF32)
+            F = real(T)
+            @testset "$T" begin
+                for n in (16, 64, 256, 1024)
+                    x = randn(T, n)
+                    result = AbstractFFTs.fft(x)
+                    expected = FFTW.fft(x)
+                    if F == Float64
+                        @test result ≈ expected
+                    else
+                        @test result ≈ expected rtol=sqrt(eps(Float32))
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "mul! variant" begin
+        x = randn(ComplexF64, 256)
+        p = plan_fft(x)
+        y = similar(x)
+        mul!(y, p, x)
+        @test y ≈ FFTW.fft(x)
+    end
+
+    @testset "bfft roundtrip" begin
+        for T in (ComplexF64, ComplexF32)
+            F = real(T)
+            @testset "$T" begin
+                for n in (16, 256, 1024)
+                    x = randn(T, n)
+                    X = AbstractFFTs.fft(x)
+                    y = AbstractFFTs.bfft(X)
+                    if F == Float64
+                        @test y ≈ n * x
+                    else
+                        @test y ≈ n * x rtol=sqrt(eps(Float32))
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "ifft roundtrip" begin
+        for T in (ComplexF64, ComplexF32)
+            F = real(T)
+            @testset "$T" begin
+                for n in (16, 256, 1024)
+                    x = randn(T, n)
+                    @test AbstractFFTs.ifft(AbstractFFTs.fft(x)) ≈ x rtol=(F == Float64 ? 1e-10 : sqrt(eps(Float32)))
+                end
+            end
+        end
+    end
+
+    @testset "inv(plan) and p \\ x" begin
+        x = randn(ComplexF64, 256)
+        p = plan_fft(x)
+        X = p * x
+        pinv = inv(p)
+        @test pinv * X ≈ x
+        @test inv(p) === pinv
+        @test p \ X ≈ x
+    end
+
+    @testset "Known values" begin
+        x_impulse = ComplexF64[1, 0, 0, 0]
+        @test AbstractFFTs.fft(x_impulse) ≈ ComplexF64[1, 1, 1, 1]
+        x_const = ComplexF64[1, 1, 1, 1]
+        @test AbstractFFTs.fft(x_const) ≈ ComplexF64[4, 0, 0, 0]
+    end
+
+    @testset "Parseval's theorem" begin
+        x = randn(ComplexF64, 256)
+        X = AbstractFFTs.fft(x)
+        @test sum(abs2, x) ≈ sum(abs2, X) / 256
+    end
+
+    @testset "2D Forward FFT matches FFTW" begin
+        for T in (ComplexF64, ComplexF32)
+            F = real(T)
+            @testset "$T" begin
+                for (nr, nc) in ((4, 4), (8, 16), (16, 8), (32, 32))
+                    x = randn(T, nr, nc)
+                    result = AbstractFFTs.fft(x)
+                    expected = FFTW.fft(x)
+                    if F == Float64
+                        @test result ≈ expected
+                    else
+                        @test result ≈ expected rtol=sqrt(eps(Float32))
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "2D mul! variant" begin
+        x = randn(ComplexF64, 16, 32)
+        p = plan_fft(x)
+        y = similar(x)
+        mul!(y, p, x)
+        @test y ≈ FFTW.fft(x)
+    end
+
+    @testset "2D ifft roundtrip" begin
+        for T in (ComplexF64, ComplexF32)
+            F = real(T)
+            @testset "$T" begin
+                for (nr, nc) in ((4, 8), (16, 16))
+                    x = randn(T, nr, nc)
+                    @test AbstractFFTs.ifft(AbstractFFTs.fft(x)) ≈ x rtol=(F == Float64 ? 1e-10 : sqrt(eps(Float32)))
+                end
+            end
+        end
+    end
+
+    @testset "2D inv(plan) and p \\ x" begin
+        x = randn(ComplexF64, 16, 16)
+        p = plan_fft(x)
+        X = p * x
+        pinv = inv(p)
+        @test pinv * X ≈ x
+        @test p \ X ≈ x
+    end
+
+    @testset "2D error cases" begin
+        @test_throws ArgumentError plan_fft(randn(ComplexF64, 3, 4))
+        @test_throws ArgumentError plan_fft(randn(ComplexF64, 4, 6))
+    end
+
+    @testset "Error cases" begin
+        @test_throws ArgumentError plan_fft(randn(ComplexF64, 100))
+        @test_throws ArgumentError plan_fft(ComplexF64[])
     end
 end
 


### PR DESCRIPTION
## Summary

- Refactor the FFT API in `src/DSP.jl` to use AbstractFFTs naming conventions (`fft`, `ifft`, `bfft`, `plan_fft`)
- Add a Julia package extension (`ext/AppleAccelerateAbstractFFTsExt.jl`) that integrates Apple's vDSP FFT with the standard [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl) interface
- Both 1D vectors and 2D matrices are supported

### API changes in DSP.jl

| Old API | New API |
|---------|---------|
| `fft(x, setup)` | `fft(x, setup)` or `fft(x)` |
| `fft(x, setup, FFT_INVERSE)` | `bfft(x, setup)` or `bfft(x)` |
| Manual `bfft ./ n` | `ifft(x, setup)` or `ifft(x)` |
| `fft2d(x, setup)` | `fft(x, setup)` (dispatches on Matrix) |
| `plan_fft(n, T)` | `plan_fft(n, T)` or `plan_fft(x)` |

- `fft`/`bfft`/`ifft` dispatch on `Vector` vs `Matrix` — no more separate `fft2d`
- Convenience forms without `setup` auto-create a plan
- `FFT_FORWARD`/`FFT_INVERSE` are now internal implementation details

### AbstractFFTs extension

- `VDSPFFTPlan` / `VDSPBFFTPlan` structs subtyping `AbstractFFTs.Plan{Complex{T}}`
- Implements `plan_fft`, `plan_bfft`, `plan_inv`, `mul!`, `AdjointStyle` for 1D and 2D
- `plan_ifft` auto-derived by AbstractFFTs via `ScaledPlan(plan_bfft, 1/n)`
- Forward and inverse plans share the same `FFTSetup`
- Dispatches on `Vector{Complex{T}}` / `Matrix{Complex{T}}` (more specific than FFTW's `StridedArray`), so FFTW handles strided views and 3D+ arrays
- Guarded with `@static if Sys.isapple()`

### Not supported

- In-place plans (`plan_fft!` / `plan_bfft!`) — vDSP is out-of-place only
- Real FFTs (`rfft` / `irfft`) — not yet wrapped
- 3D+ arrays — vDSP only supports 1D and 2D FFT

## Test plan

- [x] 1D forward FFT vs FFTW for ComplexF32/ComplexF64
- [x] 2D forward FFT vs FFTW for various matrix sizes
- [x] `bfft` and `ifft` roundtrips (1D and 2D)
- [x] `mul!` variant (1D and 2D)
- [x] `inv(plan)` and `p \ x` (1D and 2D)
- [x] Known values (impulse, constant), Parseval's theorem, linearity, circular shift
- [x] Error cases: non-power-of-2, empty array, non-power-of-2 matrix dimensions
- [x] AbstractFFTs extension tests for all of the above
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)