### PR TITLE
Add 2D complex FFT wrapping vDSP_fft2d_zop

### DIFF
--- a/docs/src/dsp.md
+++ b/docs/src/dsp.md
@@ -23,6 +23,23 @@ nothing # hide
 
 Both `ComplexF64` and `ComplexF32` inputs are supported. Input length must be a power of 2.
 
+## 2D FFT
+
+```@example dsp
+# Create an FFT plan (must accommodate the largest dimension)
+setup = AppleAccelerate.plan_fft(32, Float64)
+
+# Forward 2D FFT
+x = randn(ComplexF64, 16, 32)
+X = AppleAccelerate.fft2d(x, setup)
+
+# Inverse 2D FFT (unnormalized — divide by nrows*ncols to recover original)
+x_recovered = AppleAccelerate.fft2d(X, setup, AppleAccelerate.FFT_INVERSE) ./ (16 * 32)
+nothing # hide
+```
+
+Both dimensions must be powers of 2. The `FFTSetup` must be created with `n >= max(nrows, ncols)`.
+
 ## DCT (Discrete Cosine Transform)
 
 Float32 only. Supports DCT types II, III, and IV.

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -467,3 +467,65 @@ function fft(r::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int=FFT
 
     return complex.(retr, reti)
 end
+
+"""
+    fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction=FFT_FORWARD)
+
+Compute the 2D complex FFT of matrix `r` using the given `FFTSetup`.
+Both dimensions must be powers of 2. The `setup` must have been created with
+`n >= max(size(r)...)`.
+"""
+function fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int=FFT_FORWARD)
+    nrows, ncols = size(r)
+    @assert ispow2(nrows) && ispow2(ncols) "dimensions must be powers of 2"
+    log2nr = trailing_zeros(nrows)
+    log2nc = trailing_zeros(ncols)
+
+    realp = real.(r)
+    imagp = imag.(r)
+    retr = Matrix{Float64}(undef, nrows, ncols)
+    reti = Matrix{Float64}(undef, nrows, ncols)
+
+    GC.@preserve realp imagp retr reti begin
+        input = DSPDoubleSplitComplex(pointer(realp), pointer(imagp))
+        output = DSPDoubleSplitComplex(pointer(retr), pointer(reti))
+        ccall(("vDSP_fft2d_zopD", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong, Clong,
+               Ref{DSPDoubleSplitComplex}, Clong, Clong, Culong, Culong, Cint),
+              setup.plan, input, SIGNAL_STRIDE, 0, output, SIGNAL_STRIDE, 0,
+              log2nr, log2nc, direction)
+    end
+
+    return complex.(retr, reti)
+end
+
+"""
+    fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction=FFT_FORWARD)
+
+Compute the 2D complex FFT of matrix `r` using the given `FFTSetup`.
+Both dimensions must be powers of 2. The `setup` must have been created with
+`n >= max(size(r)...)`.
+"""
+function fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int=FFT_FORWARD)
+    nrows, ncols = size(r)
+    @assert ispow2(nrows) && ispow2(ncols) "dimensions must be powers of 2"
+    log2nr = trailing_zeros(nrows)
+    log2nc = trailing_zeros(ncols)
+
+    realp = Float32.(real.(r))
+    imagp = Float32.(imag.(r))
+    retr = Matrix{Float32}(undef, nrows, ncols)
+    reti = Matrix{Float32}(undef, nrows, ncols)
+
+    GC.@preserve realp imagp retr reti begin
+        input = DSPSplitComplex(pointer(realp), pointer(imagp))
+        output = DSPSplitComplex(pointer(retr), pointer(reti))
+        ccall(("vDSP_fft2d_zop", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong, Clong,
+               Ref{DSPSplitComplex}, Clong, Clong, Culong, Culong, Cint),
+              setup.plan, input, SIGNAL_STRIDE, 0, output, SIGNAL_STRIDE, 0,
+              log2nr, log2nc, direction)
+    end
+
+    return complex.(retr, reti)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,46 @@ end
     end
 end
 
+@testset "FFT2D::Float64" begin
+    for (nr, nc) in ((4, 4), (8, 16), (16, 8), (32, 32))
+        r = randn(ComplexF64, nr, nc)
+        plan = AppleAccelerate.plan_fft(max(nr, nc), Float64)
+        result = AppleAccelerate.fft2d(r, plan)
+        expected = FFTW.fft(r)
+        @test result ≈ expected
+    end
+end
+
+@testset "FFT2D::Float32" begin
+    for (nr, nc) in ((4, 4), (8, 16), (16, 8), (32, 32))
+        r = randn(ComplexF32, nr, nc)
+        plan = AppleAccelerate.plan_fft(max(nr, nc), Float32)
+        result = AppleAccelerate.fft2d(r, plan)
+        expected = FFTW.fft(r)
+        @test result ≈ expected rtol=sqrt(eps(Float32))
+    end
+end
+
+@testset "IFFT2D roundtrip" begin
+    for T in (ComplexF64, ComplexF32)
+        F = real(T)
+        @testset "$T" begin
+            for (nr, nc) in ((4, 8), (16, 16))
+                r = randn(T, nr, nc)
+                plan = AppleAccelerate.plan_fft(max(nr, nc), F)
+                fwd = AppleAccelerate.fft2d(r, plan, AppleAccelerate.FFT_FORWARD)
+                inv_result = AppleAccelerate.fft2d(fwd, plan, AppleAccelerate.FFT_INVERSE)
+                ntotal = nr * nc
+                if F == Float64
+                    @test inv_result ./ ntotal ≈ r
+                else
+                    @test inv_result ./ ntotal ≈ r rtol=sqrt(eps(Float32))
+                end
+            end
+        end
+    end
+end
+
 
 for T in (Float32,  Float64)
     @testset "Convolution & Correlation::$T" begin


### PR DESCRIPTION
## Summary

- Add `fft2d()` for `Matrix{ComplexF64}` and `Matrix{ComplexF32}`, wrapping Apple's `vDSP_fft2d_zopD` and `vDSP_fft2d_zop` (out-of-place 2D complex FFT)
- Both dimensions must be powers of 2; the `FFTSetup` must be created with `n >= max(nrows, ncols)`
- Uses column-major stride mapping (`IA0=1, IA1=0` which defaults to `nrows`)

## Test plan

- [x] Forward 2D FFT matches FFTW for Float32 and Float64
- [x] Square and non-square sizes: 4x4, 8x16, 16x8, 32x32
- [x] IFFT roundtrip: `fft2d(fft2d(x, forward), inverse) / (nr*nc) ≈ x` for both precisions
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)