### PR TITLE
Convert doc examples to executable @example blocks

### DIFF
--- a/docs/src/blas.md
+++ b/docs/src/blas.md
@@ -4,7 +4,7 @@ AppleAccelerate forwards BLAS and LAPACK calls to Apple's Accelerate framework v
 
 ## Loading
 
-```julia
+```@example
 using AppleAccelerate
 ```
 

--- a/docs/src/dsp.md
+++ b/docs/src/dsp.md
@@ -2,9 +2,13 @@
 
 AppleAccelerate wraps vDSP functions for signal processing, including convolution, correlation, filtering, windowing, DCT, and FFT.
 
+```@setup dsp
+using AppleAccelerate
+```
+
 ## FFT
 
-```julia
+```@example dsp
 # Create an FFT plan (reusable for same-size transforms)
 setup = AppleAccelerate.plan_fft(1024, Float64)
 
@@ -14,6 +18,7 @@ X = AppleAccelerate.fft(x, setup)
 
 # Inverse FFT
 x_recovered = AppleAccelerate.fft(X, setup, AppleAccelerate.FFT_INVERSE)
+nothing # hide
 ```
 
 Both `ComplexF64` and `ComplexF32` inputs are supported. Input length must be a power of 2.
@@ -31,31 +36,35 @@ AppleAccelerate.dct
 
 `conv(X, K)` computes the convolution of vectors `X` and `K`. `conv!(result, X, K)` stores the result in a preallocated vector.
 
-```julia
+```@example dsp
 X = randn(Float64, 100)
 K = randn(Float64, 10)
 result = AppleAccelerate.conv(X, K)  # length = length(X) + length(K) - 1
+nothing # hide
 ```
 
 ## Cross-Correlation
 
 `xcorr(X, Y)` computes the cross-correlation. `xcorr(X)` computes auto-correlation.
 
-```julia
+```@example dsp
 X = randn(Float64, 100)
 Y = randn(Float64, 100)
 result = AppleAccelerate.xcorr(X, Y)
+nothing # hide
 ```
 
 ## Biquad Filtering
 
 IIR filtering via cascaded biquad sections (Float64 only).
 
-```julia
+```@example dsp
+X = randn(Float64, 100)
 coefficients = randn(5)  # 5 coefficients per section
 bq = AppleAccelerate.biquadcreate(coefficients, 1)
 delays = zeros(4)
 result = AppleAccelerate.biquad(X, delays, length(X), bq)
+nothing # hide
 ```
 
 ## Window Functions

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,20 +20,21 @@ Pkg.add("AppleAccelerate")
 
 AppleAccelerate automatically forwards BLAS and LAPACK calls to Apple's Accelerate framework on package load:
 
-```julia
+```@example
 using AppleAccelerate
 using LinearAlgebra
 
 # All BLAS/LAPACK operations now use Accelerate
 A = randn(1000, 1000)
 F = lu(A)  # Uses Accelerate LAPACK
+nothing # hide
 ```
 
 ### Vectorized Math
 
 AppleAccelerate provides accelerated element-wise math operations via Apple's vecLib:
 
-```julia
+```@example
 using AppleAccelerate
 
 X = randn(Float64, 10_000)
@@ -46,22 +47,24 @@ Y = AppleAccelerate.log(X)
 # Or replace Base functions for transparent acceleration
 AppleAccelerate.@replaceBase sin cos exp log sqrt
 sin.(X)  # Now uses Accelerate
+nothing # hide
 ```
 
 ### FFT
 
-```julia
+```@example
 using AppleAccelerate
 
 x = randn(ComplexF64, 1024)
 setup = AppleAccelerate.plan_fft(length(x))
 y = AppleAccelerate.fft(x, setup)
+nothing # hide
 ```
 
 ### Sparse Linear Algebra
 
-```julia
-using AppleAccelerate, SparseArrays
+```@example
+using AppleAccelerate, SparseArrays, LinearAlgebra
 
 A = sprandn(100, 100, 0.1)
 A = A + A' + 20I  # Make symmetric positive definite
@@ -70,4 +73,5 @@ b = randn(100)
 import AppleAccelerate: AAFactorization, solve
 f = AAFactorization(A)
 x = solve(f, b)
+nothing # hide
 ```

--- a/docs/src/sparse.md
+++ b/docs/src/sparse.md
@@ -2,11 +2,15 @@
 
 AppleAccelerate wraps Apple's `libSparse` library for sparse matrix operations and direct solvers.
 
+```@setup sparse
+using AppleAccelerate, SparseArrays, LinearAlgebra
+```
+
 ## AASparseMatrix
 
 A wrapper around Apple's sparse matrix format, constructed from Julia's `SparseMatrixCSC`.
 
-```julia
+```@example sparse
 using AppleAccelerate, SparseArrays
 import AppleAccelerate: AASparseMatrix, muladd!
 
@@ -15,6 +19,7 @@ A = AASparseMatrix(A_jl)
 
 x = randn(100)
 y = A * x  # Sparse matrix-vector multiply
+nothing # hide
 ```
 
 The constructor automatically detects symmetric and triangular structure and sets
@@ -30,7 +35,7 @@ AppleAccelerate.muladd!
 Lazy factorization wrapper: the factorization is computed on the first call to `solve`
 or by explicitly calling `factor!`.
 
-```julia
+```@example sparse
 import AppleAccelerate: AAFactorization, solve, solve!, factor!
 
 A = sprandn(100, 100, 0.1) + 20I
@@ -43,6 +48,7 @@ x = solve(f, b)
 # Or explicitly
 factor!(f)
 x = solve(f, b)
+nothing # hide
 ```
 
 Supported factorization types:


### PR DESCRIPTION
## Summary
- Convert 11 plain `julia` code blocks across 4 doc pages to Documenter.jl `@example` blocks, so all examples are executed during doc generation and broken examples are caught automatically
- Fix Biquad example that referenced undefined `X` variable
- Fix Sparse example missing `LinearAlgebra` import (needed for `I`)

## Approach
Uses `@example` blocks (not `jldoctest`) so the code stays identical to the originals — no `julia>` prefixes, no mandatory blank lines, fully copy/paste friendly. `@setup` blocks provide shared imports for multi-example pages. `nothing # hide` lines suppress output and are invisible in rendered HTML.

## Test plan
- [x] `julia --project=docs/ docs/make.jl` passes locally with all examples executing successfully
- [x] CI docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)