### PR TITLE
Add ~50 missing vDSP functions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,8 +11,20 @@
 
 - [`AppleAccelerate.@replaceBase`](@ref)
 - Vector-vector: `vadd`, `vsub`, `vmul`, `vdiv` (and `!` variants)
-- Vector-scalar: `vsadd`, `vssub`, `svsub`, `vsdiv`, `vsmul` (and `!` variants)
-- Reductions: `maximum`, `minimum`, `mean`, `sum`, `findmax`, `findmin`, `meanmag`, `meansqr`, `summag`, `sumsqr`
+- Vector-scalar: `vsadd`, `vssub`, `svsub`, `vsdiv`, `vsmul`, `svdiv` (and `!` variants)
+- Reductions: `maximum`, `minimum`, `mean`, `sum`, `findmax`, `findmin`, `meanmag`, `meansqr`, `summag`, `sumsqr`, `dot`, `distancesq`
+- Unary vDSP: `vneg`, `vnabs`, `vabs`, `vsq`, `vssq`, `vfrac`, `vreverse` (and `!` variants)
+- Two-vector: `vmax`, `vmin`, `vmaxmg`, `vminmg`, `vdist`, `vtmerg` (and `!` variants)
+- Compound arithmetic: `vam`, `vsbm`, `vaam`, `vsbsbm`, `vasbm`, `vpythg`, `vasm`, `vsbsm`, `vsma`, `vsmsa`, `vaddsub`, `venvlp` (and `!` variants)
+- Clipping: `vclip`, `viclip`, `vthr`, `vthres`, `vcmprs` (and `!` variants)
+- Type conversion: `vdouble`, `vsingle`
+- Ramp generation: `vramp`, `vrampmul`
+- Integration: `vrsum`, `vsimps`, `vtrapz`, `vswsum`, `vswmax` (and `!` variants)
+- Interpolation: `vintb`, `vlint`, `vqint` (and `!` variants)
+- Polynomial: `vpoly` (and `!` variant)
+- Normalization: `vnormalize` (and `!` variant)
+- Zero crossings: `nzcros`
+- Decibel conversion: `vdbcon` (and `!` variant)
 
 ## DSP & FFT
 

--- a/docs/src/array.md
+++ b/docs/src/array.md
@@ -4,7 +4,7 @@ AppleAccelerate wraps Apple's vecLib (`vv*` and `vDSP_*` functions) to provide a
 
 These functions are **not exported** to avoid conflicts with Base. Access them via the `AppleAccelerate.` prefix or use `@replaceBase` to override Base functions.
 
-## Element-wise Math Functions
+## Element-wise Math Functions (vecLib)
 
 ### One-argument functions
 
@@ -38,6 +38,20 @@ Each function `f` has an allocating variant `f(X)` and a mutating variant `f!(ou
 | `sincos(X)` | Returns `(sin(X), cos(X))` tuple |
 | `cis(X)` | Returns `Complex` array `cos(X) + im*sin(X)` |
 
+## Unary vDSP Operations
+
+These functions wrap `vDSP_*` routines. Each has an allocating variant `f(X)` and a mutating variant `f!(result, X)`:
+
+| Function | Description |
+|----------|-------------|
+| `vneg(X)` | Negate: `-X` |
+| `vnabs(X)` | Negative absolute value: `-abs.(X)` |
+| `vabs(X)` | Absolute value (vDSP) |
+| `vsq(X)` | Square: `X.^2` |
+| `vssq(X)` | Signed square: `X .* abs.(X)` |
+| `vfrac(X)` | Fractional part: `X .- trunc.(X)` |
+| `vreverse(X)` | Reverse vector (`vreverse!` operates in-place) |
+
 ## Vector Reductions
 
 | Function | Description |
@@ -51,8 +65,12 @@ Each function `f` has an allocating variant `f(X)` and a mutating variant `f!(ou
 | `summag(X)` | Sum of absolute values |
 | `sumsqr(X)` | Sum of squares |
 | `sumssqr(X)` | Sum of signed squares |
+| `dot(X, Y)` | Dot product: `sum(X .* Y)` |
+| `distancesq(X, Y)` | Squared distance: `sum((X .- Y).^2)` |
 
 ## Vector-Vector Operations
+
+### Arithmetic
 
 | Function | Description |
 |----------|-------------|
@@ -60,6 +78,17 @@ Each function `f` has an allocating variant `f(X)` and a mutating variant `f!(ou
 | `vsub(X, Y)` | Element-wise subtraction |
 | `vmul(X, Y)` | Element-wise multiplication |
 | `vdiv(X, Y)` | Element-wise division |
+
+### Comparison & Distance
+
+| Function | Description |
+|----------|-------------|
+| `vmax(X, Y)` | Element-wise maximum |
+| `vmin(X, Y)` | Element-wise minimum |
+| `vmaxmg(X, Y)` | Element-wise max of magnitudes: `max.(abs.(X), abs.(Y))` |
+| `vminmg(X, Y)` | Element-wise min of magnitudes: `min.(abs.(X), abs.(Y))` |
+| `vdist(X, Y)` | Element-wise distance: `hypot.(X, Y)` |
+| `vtmerg(X, Y)` | Tapered merge of two vectors |
 
 ## Vector-Scalar Operations
 
@@ -70,8 +99,111 @@ Each function `f` has an allocating variant `f(X)` and a mutating variant `f!(ou
 | `svsub(X, c)` | `c .- X` |
 | `vsmul(X, c)` | `X .* c` |
 | `vsdiv(X, c)` | `X ./ c` |
+| `svdiv(X, c)` | `c ./ X` (scalar divided by vector) |
 
 All vector operations have mutating `!` variants (e.g., `vadd!(result, X, Y)`).
+
+## Compound Arithmetic
+
+These operations fuse multiple arithmetic steps into a single vDSP call for better performance.
+
+### Three-vector operations
+
+| Function | Description |
+|----------|-------------|
+| `vam(A, B, C)` | `(A .+ B) .* C` |
+| `vsbm(A, B, C)` | `(A .- B) .* C` |
+| `venvlp(A, B, C)` | Signal envelope |
+
+### Four-vector operations
+
+| Function | Description |
+|----------|-------------|
+| `vaam(A, B, C, D)` | `(A .+ B) .* (C .+ D)` |
+| `vsbsbm(A, B, C, D)` | `(A .- B) .* (C .- D)` |
+| `vasbm(A, B, C, D)` | `(A .+ B) .* (C .- D)` |
+| `vpythg(A, B, C, D)` | `sqrt.((A .- C).^2 .+ (B .- D).^2)` |
+
+### Vector-vector-scalar operations
+
+| Function | Description |
+|----------|-------------|
+| `vasm(A, B, c)` | `(A .+ B) .* c` |
+| `vsbsm(A, B, c)` | `(A .- B) .* c` |
+| `vsma(A, b, C)` | `A .* b .+ C` |
+| `vsmsa(A, b, c)` | `A .* b .+ c` |
+
+### Dual output
+
+| Function | Description |
+|----------|-------------|
+| `vaddsub(A, B)` | Returns `(A .+ B, B .- A)` as two vectors |
+
+## Clipping & Thresholding
+
+| Function | Description |
+|----------|-------------|
+| `vclip(X, low, high)` | Clip values to `[low, high]` |
+| `viclip(X, low, high)` | Inverted clip: pass values outside `[low, high]` |
+| `vthr(X, threshold)` | `max.(X, threshold)` |
+| `vthres(X, threshold)` | `X[n] >= threshold ? X[n] : 0` |
+| `vcmprs(X, gate)` | Compress: keep `X[n]` where `gate[n] != 0` |
+
+## Type Conversion
+
+| Function | Description |
+|----------|-------------|
+| `vdouble(X::Vector{Float32})` | Convert to `Vector{Float64}` |
+| `vsingle(X::Vector{Float64})` | Convert to `Vector{Float32}` |
+
+## Ramp Generation
+
+| Function | Description |
+|----------|-------------|
+| `vramp(start, step, n)` | Generate ramp: `start + i*step` for `i = 0, ..., n-1` |
+| `vrampmul(X, start, step)` | Multiply vector by generated ramp |
+
+## Integration & Running Operations
+
+| Function | Description |
+|----------|-------------|
+| `vrsum(X, scale)` | Running sum scaled by `scale` |
+| `vsimps(X, step)` | Simpson's rule integration |
+| `vtrapz(X, step)` | Trapezoidal integration |
+| `vswsum(X, window)` | Sliding window sum |
+| `vswmax(X, window)` | Sliding window maximum |
+
+## Interpolation
+
+| Function | Description |
+|----------|-------------|
+| `vintb(A, B, t)` | Linear interpolation: `A .+ t .* (B .- A)` |
+| `vlint(table, indices)` | Linear interpolation lookup from table |
+| `vqint(table, indices)` | Quadratic interpolation lookup from table |
+
+## Polynomial Evaluation
+
+| Function | Description |
+|----------|-------------|
+| `vpoly(coeffs, X)` | Evaluate polynomial at each point in `X`. Coefficients are ordered highest degree first: `[a_P, a_{P-1}, ..., a_1, a_0]` |
+
+## Normalization
+
+| Function | Description |
+|----------|-------------|
+| `vnormalize(X)` | Returns `(normalized_X, mean, stddev)` where `normalized_X = (X .- mean) ./ stddev` |
+
+## Zero Crossings
+
+| Function | Description |
+|----------|-------------|
+| `nzcros(X, max_crossings=0)` | Find zero crossings. Returns `(indices, count)`. Default `max_crossings=0` means up to `length(X)`. |
+
+## Decibel Conversion
+
+| Function | Description |
+|----------|-------------|
+| `vdbcon(X, ref, power=true)` | Convert to decibels. `power=true`: `10*log10(X/ref)`. `power=false`: `20*log10(X/ref)`. |
 
 ## Broadcasting
 

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -330,3 +330,571 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     end
 end
 
+# ============================================================
+# vDSP Unary vector operations
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+
+    for (f, fa) in ((:vneg, :vneg), (:vnabs, :vnabs), (:vsq, :vsq),
+                    (:vssq, :vssq), (:vfrac, :vfrac), (:vabs, :vabs))
+        f! = Symbol("$(f)!")
+        @eval begin
+            function ($f!)(result::Vector{$T}, X::Vector{$T})
+                ccall(($(string("vDSP_", fa, suff)), libacc), Cvoid,
+                      (Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                      X, 1, result, 1, length(X))
+                return result
+            end
+            function ($f)(X::Vector{$T})
+                result = similar(X)
+                ($f!)(result, X)
+            end
+        end
+    end
+
+    # vreverse: in-place only
+    @eval begin
+        function vreverse!(X::Vector{$T})
+            ccall(($(string("vDSP_vrvrs", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, UInt64),
+                  X, 1, length(X))
+            return X
+        end
+        function vreverse(X::Vector{$T})
+            Y = copy(X)
+            vreverse!(Y)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Two-vector element-wise operations
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+
+    for (f, fa) in ((:vmax, :vmax), (:vmin, :vmin),
+                    (:vmaxmg, :vmaxmg), (:vminmg, :vminmg),
+                    (:vdist, :vdist))
+        f! = Symbol("$(f)!")
+        @eval begin
+            function ($f!)(result::Vector{$T}, X::Vector{$T}, Y::Vector{$T})
+                ccall(($(string("vDSP_", fa, suff)), libacc), Cvoid,
+                      (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                      X, 1, Y, 1, result, 1, length(X))
+                return result
+            end
+            function ($f)(X::Vector{$T}, Y::Vector{$T})
+                result = similar(X)
+                ($f!)(result, X, Y)
+            end
+        end
+    end
+
+    # vtmerg: tapered merge — C[n] = A[n] + (B[n] - A[n]) * n/(N-1)
+    # Signature same as two-vector ops
+    @eval begin
+        function vtmerg!(result::Vector{$T}, X::Vector{$T}, Y::Vector{$T})
+            ccall(($(string("vDSP_vtmerg", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  X, 1, Y, 1, result, 1, length(X))
+            return result
+        end
+        function vtmerg(X::Vector{$T}, Y::Vector{$T})
+            result = similar(X)
+            vtmerg!(result, X, Y)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Scalar-vector divide: C[n] = A / B[n]
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function svdiv!(result::Vector{$T}, X::Vector{$T}, c::$T)
+            ccall(($(string("vDSP_svdiv", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  Ref(c), X, 1, result, 1, length(X))
+            return result
+        end
+        function svdiv(X::Vector{$T}, c::$T)
+            result = similar(X)
+            svdiv!(result, X, c)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Compound arithmetic: 3-vector ops (A, B, C → D)
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+
+    # vam: (A+B)*C, vsbm: (A-B)*C
+    for (f, fa) in ((:vam, :vam), (:vsbm, :vsbm))
+        f! = Symbol("$(f)!")
+        @eval begin
+            function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+                ccall(($(string("vDSP_", fa, suff)), libacc), Cvoid,
+                      (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                      A, 1, B, 1, C, 1, result, 1, length(A))
+                return result
+            end
+            function ($f)(A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+                result = similar(A)
+                ($f!)(result, A, B, C)
+            end
+        end
+    end
+
+    # venvlp: signal envelope — same 3-vector pattern
+    @eval begin
+        function venvlp!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+            ccall(($(string("vDSP_venvlp", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  A, 1, B, 1, C, 1, result, 1, length(A))
+            return result
+        end
+        function venvlp(A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+            result = similar(A)
+            venvlp!(result, A, B, C)
+        end
+    end
+
+    # 4-vector ops (A, B, C, D → E)
+    for (f, fa) in ((:vaam, :vaam), (:vsbsbm, :vsbsbm), (:vasbm, :vasbm))
+        f! = Symbol("$(f)!")
+        @eval begin
+            function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+                ccall(($(string("vDSP_", fa, suff)), libacc), Cvoid,
+                      (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                      A, 1, B, 1, C, 1, D, 1, result, 1, length(A))
+                return result
+            end
+            function ($f)(A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+                result = similar(A)
+                ($f!)(result, A, B, C, D)
+            end
+        end
+    end
+
+    # vpythg: sqrt((A-C)^2 + (B-D)^2) — same 4-vector pattern
+    @eval begin
+        function vpythg!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+            ccall(($(string("vDSP_vpythg", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  A, 1, B, 1, C, 1, D, 1, result, 1, length(A))
+            return result
+        end
+        function vpythg(A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+            result = similar(A)
+            vpythg!(result, A, B, C, D)
+        end
+    end
+
+    # 2 vectors + 1 scalar → D: vasm: (A+B)*C_scalar, vsbsm: (A-B)*C_scalar
+    for (f, fa) in ((:vasm, :vasm), (:vsbsm, :vsbsm))
+        f! = Symbol("$(f)!")
+        @eval begin
+            function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, c::$T)
+                ccall(($(string("vDSP_", fa, suff)), libacc), Cvoid,
+                      (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                      A, 1, B, 1, Ref(c), result, 1, length(A))
+                return result
+            end
+            function ($f)(A::Vector{$T}, B::Vector{$T}, c::$T)
+                result = similar(A)
+                ($f!)(result, A, B, c)
+            end
+        end
+    end
+
+    # vsma: A*B_scalar + C
+    @eval begin
+        function vsma!(result::Vector{$T}, A::Vector{$T}, b::$T, C::Vector{$T})
+            ccall(($(string("vDSP_vsma", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  A, 1, Ref(b), C, 1, result, 1, length(A))
+            return result
+        end
+        function vsma(A::Vector{$T}, b::$T, C::Vector{$T})
+            result = similar(A)
+            vsma!(result, A, b, C)
+        end
+    end
+
+    # vsmsa: A*B_scalar + C_scalar
+    @eval begin
+        function vsmsa!(result::Vector{$T}, A::Vector{$T}, b::$T, c::$T)
+            ccall(($(string("vDSP_vsmsa", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  A, 1, Ref(b), Ref(c), result, 1, length(A))
+            return result
+        end
+        function vsmsa(A::Vector{$T}, b::$T, c::$T)
+            result = similar(A)
+            vsmsa!(result, A, b, c)
+        end
+    end
+
+    # vaddsub: returns (A+B, A-B) as two vectors
+    @eval begin
+        function vaddsub!(add_result::Vector{$T}, sub_result::Vector{$T}, A::Vector{$T}, B::Vector{$T})
+            ccall(($(string("vDSP_vaddsub", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  A, 1, B, 1, add_result, 1, sub_result, 1, length(A))
+            return (add_result, sub_result)
+        end
+        function vaddsub(A::Vector{$T}, B::Vector{$T})
+            add_result = similar(A)
+            sub_result = similar(A)
+            vaddsub!(add_result, sub_result, A, B)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Scalar reductions: dot product, distance squared
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function dot(X::Vector{$T}, Y::Vector{$T})
+            val = Ref{$T}(0.0)
+            ccall(($(string("vDSP_dotpr", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, UInt64),
+                  X, 1, Y, 1, val, length(X))
+            return val[]
+        end
+        function distancesq(X::Vector{$T}, Y::Vector{$T})
+            val = Ref{$T}(0.0)
+            ccall(($(string("vDSP_distancesq", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, UInt64),
+                  X, 1, Y, 1, val, length(X))
+            return val[]
+        end
+    end
+end
+
+# ============================================================
+# vDSP Clipping & thresholding
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    # vclip: clip to [low, high]
+    @eval begin
+        function vclip!(result::Vector{$T}, X::Vector{$T}, low::$T, high::$T)
+            ccall(($(string("vDSP_vclip", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(low), Ref(high), result, 1, length(X))
+            return result
+        end
+        function vclip(X::Vector{$T}, low::$T, high::$T)
+            result = similar(X)
+            vclip!(result, X, low, high)
+        end
+    end
+
+    # viclip: inverted clip (pass through values outside [low, high])
+    @eval begin
+        function viclip!(result::Vector{$T}, X::Vector{$T}, low::$T, high::$T)
+            ccall(($(string("vDSP_viclip", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(low), Ref(high), result, 1, length(X))
+            return result
+        end
+        function viclip(X::Vector{$T}, low::$T, high::$T)
+            result = similar(X)
+            viclip!(result, X, low, high)
+        end
+    end
+
+    # vthr: threshold — X[n] >= threshold ? X[n] : threshold
+    @eval begin
+        function vthr!(result::Vector{$T}, X::Vector{$T}, threshold::$T)
+            ccall(($(string("vDSP_vthr", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(threshold), result, 1, length(X))
+            return result
+        end
+        function vthr(X::Vector{$T}, threshold::$T)
+            result = similar(X)
+            vthr!(result, X, threshold)
+        end
+    end
+
+    # vthres: threshold — X[n] >= threshold ? X[n] : 0
+    @eval begin
+        function vthres!(result::Vector{$T}, X::Vector{$T}, threshold::$T)
+            ccall(($(string("vDSP_vthres", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(threshold), result, 1, length(X))
+            return result
+        end
+        function vthres(X::Vector{$T}, threshold::$T)
+            result = similar(X)
+            vthres!(result, X, threshold)
+        end
+    end
+
+    # vcmprs: compress — keep X[n] where gate[n] != 0
+    @eval begin
+        function vcmprs!(result::Vector{$T}, X::Vector{$T}, gate::Vector{$T})
+            ccall(($(string("vDSP_vcmprs", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
+                  X, 1, gate, 1, result, 1, length(X))
+            return result
+        end
+        function vcmprs(X::Vector{$T}, gate::Vector{$T})
+            result = similar(X)
+            vcmprs!(result, X, gate)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Type conversion
+# ============================================================
+function vdouble(X::Vector{Float32})
+    result = Vector{Float64}(undef, length(X))
+    ccall(("vDSP_vspdp", libacc), Cvoid,
+          (Ptr{Float32}, Int64, Ptr{Float64}, Int64, UInt64),
+          X, 1, result, 1, length(X))
+    return result
+end
+
+function vsingle(X::Vector{Float64})
+    result = Vector{Float32}(undef, length(X))
+    ccall(("vDSP_vdpsp", libacc), Cvoid,
+          (Ptr{Float64}, Int64, Ptr{Float32}, Int64, UInt64),
+          X, 1, result, 1, length(X))
+    return result
+end
+
+# ============================================================
+# vDSP Ramp generation
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function vramp(start::$T, step::$T, n::Integer)
+            result = Vector{$T}(undef, n)
+            ccall(($(string("vDSP_vramp", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  Ref(start), Ref(step), result, 1, n)
+            return result
+        end
+
+        function vrampmul!(result::Vector{$T}, X::Vector{$T}, start::$T, step::$T)
+            s = Ref{$T}(start)
+            ccall(($(string("vDSP_vrampmul", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, s, Ref(step), result, 1, length(X))
+            return result
+        end
+        function vrampmul(X::Vector{$T}, start::$T, step::$T)
+            result = similar(X)
+            vrampmul!(result, X, start, step)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Integration & running operations
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    # vrsum: running sum scaled by scale
+    @eval begin
+        function vrsum!(result::Vector{$T}, X::Vector{$T}, scale::$T)
+            ccall(($(string("vDSP_vrsum", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(scale), result, 1, length(X))
+            return result
+        end
+        function vrsum(X::Vector{$T}, scale::$T)
+            result = similar(X)
+            vrsum!(result, X, scale)
+        end
+    end
+
+    # vsimps: Simpson's rule integration
+    @eval begin
+        function vsimps!(result::Vector{$T}, X::Vector{$T}, step::$T)
+            ccall(($(string("vDSP_vsimps", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(step), result, 1, length(X))
+            return result
+        end
+        function vsimps(X::Vector{$T}, step::$T)
+            result = similar(X)
+            vsimps!(result, X, step)
+        end
+    end
+
+    # vtrapz: trapezoidal integration
+    @eval begin
+        function vtrapz!(result::Vector{$T}, X::Vector{$T}, step::$T)
+            ccall(($(string("vDSP_vtrapz", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  X, 1, Ref(step), result, 1, length(X))
+            return result
+        end
+        function vtrapz(X::Vector{$T}, step::$T)
+            result = similar(X)
+            vtrapz!(result, X, step)
+        end
+    end
+
+    # vswsum: sliding window sum
+    @eval begin
+        function vswsum!(result::Vector{$T}, X::Vector{$T}, window::Integer)
+            n_out = length(X) - window + 1
+            ccall(($(string("vDSP_vswsum", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64, UInt64),
+                  X, 1, result, 1, n_out, window)
+            return result
+        end
+        function vswsum(X::Vector{$T}, window::Integer)
+            n_out = length(X) - window + 1
+            result = Vector{$T}(undef, n_out)
+            vswsum!(result, X, window)
+        end
+    end
+
+    # vswmax: sliding window maximum
+    @eval begin
+        function vswmax!(result::Vector{$T}, X::Vector{$T}, window::Integer)
+            n_out = length(X) - window + 1
+            ccall(($(string("vDSP_vswmax", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64, UInt64),
+                  X, 1, result, 1, n_out, window)
+            return result
+        end
+        function vswmax(X::Vector{$T}, window::Integer)
+            n_out = length(X) - window + 1
+            result = Vector{$T}(undef, n_out)
+            vswmax!(result, X, window)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Interpolation
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    # vintb: interpolate D[n] = A[n] + t*(B[n]-A[n])
+    @eval begin
+        function vintb!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, t::$T)
+            ccall(($(string("vDSP_vintb", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64),
+                  A, 1, B, 1, Ref(t), result, 1, length(A))
+            return result
+        end
+        function vintb(A::Vector{$T}, B::Vector{$T}, t::$T)
+            result = similar(A)
+            vintb!(result, A, B, t)
+        end
+    end
+
+    # vlint: linear interpolation lookup
+    @eval begin
+        function vlint!(result::Vector{$T}, table::Vector{$T}, indices::Vector{$T})
+            ccall(($(string("vDSP_vlint", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64, UInt64),
+                  table, indices, 1, result, 1, length(indices), length(table))
+            return result
+        end
+        function vlint(table::Vector{$T}, indices::Vector{$T})
+            result = Vector{$T}(undef, length(indices))
+            vlint!(result, table, indices)
+        end
+    end
+
+    # vqint: quadratic interpolation lookup
+    @eval begin
+        function vqint!(result::Vector{$T}, table::Vector{$T}, indices::Vector{$T})
+            ccall(($(string("vDSP_vqint", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64, UInt64),
+                  table, indices, 1, result, 1, length(indices), length(table))
+            return result
+        end
+        function vqint(table::Vector{$T}, indices::Vector{$T})
+            result = Vector{$T}(undef, length(indices))
+            vqint!(result, table, indices)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Polynomial evaluation
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function vpoly!(result::Vector{$T}, coeffs::Vector{$T}, X::Vector{$T})
+            ccall(($(string("vDSP_vpoly", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64, UInt64),
+                  coeffs, 1, X, 1, result, 1, length(X), length(coeffs) - 1)
+            return result
+        end
+        function vpoly(coeffs::Vector{$T}, X::Vector{$T})
+            result = similar(X)
+            vpoly!(result, coeffs, X)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Normalization
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function vnormalize!(result::Vector{$T}, X::Vector{$T})
+            mean_out = Ref{$T}(0.0)
+            stddev_out = Ref{$T}(0.0)
+            ccall(($(string("vDSP_normalize", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, UInt64),
+                  X, 1, result, 1, mean_out, stddev_out, length(X))
+            return (result, mean_out[], stddev_out[])
+        end
+        function vnormalize(X::Vector{$T})
+            result = similar(X)
+            vnormalize!(result, X)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Zero crossings
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function nzcros(X::Vector{$T}, max_crossings::Integer=0)
+            if max_crossings <= 0
+                max_crossings = length(X)
+            end
+            indices = Vector{UInt64}(undef, max_crossings)
+            count = Ref{UInt64}(0)
+            ccall(($(string("vDSP_nzcros", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, UInt64, Ptr{UInt64}, Ptr{UInt64}, UInt64),
+                  X, 1, max_crossings, indices, count, length(X))
+            n = Int(count[])
+            return (indices[1:n], n)
+        end
+    end
+end
+
+# ============================================================
+# vDSP Decibel conversion
+# ============================================================
+for (T, suff) in ((Float32, ""), (Float64, "D"))
+    @eval begin
+        function vdbcon!(result::Vector{$T}, X::Vector{$T}, ref::$T, power::Bool=true)
+            flag = power ? UInt32(0) : UInt32(1)
+            ccall(($(string("vDSP_vdbcon", suff)), libacc), Cvoid,
+                  (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64, UInt64, UInt32),
+                  X, 1, Ref(ref), result, 1, length(X), flag)
+            return result
+        end
+        function vdbcon(X::Vector{$T}, ref::$T, power::Bool=true)
+            result = similar(X)
+            vdbcon!(result, X, ref, power)
+        end
+    end
+end
+

--- a/test/libSparseTests.jl
+++ b/test/libSparseTests.jl
@@ -205,16 +205,13 @@ import AppleAccelerate: AASparseMatrix, muladd!, AAFactorization, solve, solve!,
         @testset "QR factor/solve/ldiv" begin
             for T in (Float32, Float64)
                 @eval begin
-                    N = 3
-                    jlA = sprand($T, N, N, 0.5)
-                    while det(jlA) ≈ 0
-                        global jlA = sprand($T, N, N, 0.5)
-                    end
+                    N = 100
+                    # Generate a well-conditioned sparse matrix by adding a
+                    # diagonal shift, avoiding flaky failures from
+                    # ill-conditioned random matrices.
+                    jlA = sprand($T, N, N, 0.1) + $T(N) * I
                     test_fact = AAFactorization(jlA)
                     B = rand($T, N, N)
-                    if issymmetric(jlA)
-                        jlA[1,2] += 0.1
-                    end
                     @test solve(test_fact, B) ≈ Array(jlA) \ B
                     b = rand($T, N)
                     @test solve(test_fact, b) ≈ Array(jlA) \ b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -403,6 +403,267 @@ for T in (Float32, Float64)
     end
 end
 
+for T in (Float32, Float64)
+    @testset "vDSP Unary::$T" begin
+        X::Vector{T} = randn(N)
+        Z::Vector{T} = similar(X)
+
+        @test AppleAccelerate.vneg(X) ≈ -X
+        AppleAccelerate.vneg!(Z, X)
+        @test Z ≈ -X
+
+        @test AppleAccelerate.vnabs(X) ≈ -abs.(X)
+        AppleAccelerate.vnabs!(Z, X)
+        @test Z ≈ -abs.(X)
+
+        @test AppleAccelerate.vsq(X) ≈ X .^ 2
+        AppleAccelerate.vsq!(Z, X)
+        @test Z ≈ X .^ 2
+
+        @test AppleAccelerate.vssq(X) ≈ X .* abs.(X)
+        AppleAccelerate.vssq!(Z, X)
+        @test Z ≈ X .* abs.(X)
+
+        @test AppleAccelerate.vfrac(X) ≈ X .- trunc.(X)
+        AppleAccelerate.vfrac!(Z, X)
+        @test Z ≈ X .- trunc.(X)
+
+        @test AppleAccelerate.vabs(X) ≈ abs.(X)
+        AppleAccelerate.vabs!(Z, X)
+        @test Z ≈ abs.(X)
+
+        Y = copy(X)
+        AppleAccelerate.vreverse!(Y)
+        @test Y ≈ reverse(X)
+        @test AppleAccelerate.vreverse(X) ≈ reverse(X)
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Two-Vector::$T" begin
+        X::Vector{T} = randn(N)
+        Y::Vector{T} = randn(N)
+        Z::Vector{T} = similar(X)
+
+        @test AppleAccelerate.vmax(X, Y) ≈ max.(X, Y)
+        AppleAccelerate.vmax!(Z, X, Y)
+        @test Z ≈ max.(X, Y)
+
+        @test AppleAccelerate.vmin(X, Y) ≈ min.(X, Y)
+        AppleAccelerate.vmin!(Z, X, Y)
+        @test Z ≈ min.(X, Y)
+
+        @test AppleAccelerate.vmaxmg(X, Y) ≈ max.(abs.(X), abs.(Y))
+        AppleAccelerate.vmaxmg!(Z, X, Y)
+        @test Z ≈ max.(abs.(X), abs.(Y))
+
+        @test AppleAccelerate.vminmg(X, Y) ≈ min.(abs.(X), abs.(Y))
+        AppleAccelerate.vminmg!(Z, X, Y)
+        @test Z ≈ min.(abs.(X), abs.(Y))
+
+        @test AppleAccelerate.vdist(X, Y) ≈ hypot.(X, Y)
+        AppleAccelerate.vdist!(Z, X, Y)
+        @test Z ≈ hypot.(X, Y)
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Scalar-Vector Divide::$T" begin
+        X::Vector{T} = randn(N) .+ T(2)  # avoid division by zero
+        c::T = T(3.5)
+        Z::Vector{T} = similar(X)
+
+        @test AppleAccelerate.svdiv(X, c) ≈ c ./ X
+        AppleAccelerate.svdiv!(Z, X, c)
+        @test Z ≈ c ./ X
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Compound Arithmetic::$T" begin
+        A::Vector{T} = randn(N)
+        B::Vector{T} = randn(N)
+        C::Vector{T} = randn(N)
+        D::Vector{T} = randn(N)
+        R::Vector{T} = similar(A)
+
+        # vam: (A+B)*C
+        @test AppleAccelerate.vam(A, B, C) ≈ (A .+ B) .* C
+        AppleAccelerate.vam!(R, A, B, C)
+        @test R ≈ (A .+ B) .* C
+
+        # vsbm: (A-B)*C
+        @test AppleAccelerate.vsbm(A, B, C) ≈ (A .- B) .* C
+        AppleAccelerate.vsbm!(R, A, B, C)
+        @test R ≈ (A .- B) .* C
+
+        # vaam: (A+B)*(C+D)
+        @test AppleAccelerate.vaam(A, B, C, D) ≈ (A .+ B) .* (C .+ D)
+        AppleAccelerate.vaam!(R, A, B, C, D)
+        @test R ≈ (A .+ B) .* (C .+ D)
+
+        # vsbsbm: (A-B)*(C-D)
+        @test AppleAccelerate.vsbsbm(A, B, C, D) ≈ (A .- B) .* (C .- D)
+        AppleAccelerate.vsbsbm!(R, A, B, C, D)
+        @test R ≈ (A .- B) .* (C .- D)
+
+        # vasbm: (A+B)*(C-D)
+        @test AppleAccelerate.vasbm(A, B, C, D) ≈ (A .+ B) .* (C .- D)
+        AppleAccelerate.vasbm!(R, A, B, C, D)
+        @test R ≈ (A .+ B) .* (C .- D)
+
+        # vpythg: sqrt((A-C)^2 + (B-D)^2)
+        @test AppleAccelerate.vpythg(A, B, C, D) ≈ sqrt.((A .- C) .^ 2 .+ (B .- D) .^ 2)
+
+        # vasm: (A+B)*c
+        c::T = T(2.5)
+        @test AppleAccelerate.vasm(A, B, c) ≈ (A .+ B) .* c
+
+        # vsbsm: (A-B)*c
+        @test AppleAccelerate.vsbsm(A, B, c) ≈ (A .- B) .* c
+
+        # vsma: A*b + C
+        b::T = T(1.5)
+        @test AppleAccelerate.vsma(A, b, C) ≈ A .* b .+ C
+
+        # vsmsa: A*b + c
+        @test AppleAccelerate.vsmsa(A, b, c) ≈ A .* b .+ c
+
+        # vaddsub: returns (A+B, B-A)
+        (add_r, sub_r) = AppleAccelerate.vaddsub(A, B)
+        @test add_r ≈ A .+ B
+        @test sub_r ≈ B .- A
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Reductions::$T" begin
+        X::Vector{T} = randn(N)
+        Y::Vector{T} = randn(N)
+
+        @test AppleAccelerate.dot(X, Y) ≈ LinearAlgebra.dot(X, Y)
+        @test AppleAccelerate.distancesq(X, Y) ≈ sum((X .- Y) .^ 2)
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Clipping::$T" begin
+        X::Vector{T} = randn(N)
+
+        low::T = T(-0.5)
+        high::T = T(0.5)
+        @test AppleAccelerate.vclip(X, low, high) ≈ clamp.(X, low, high)
+        Z = similar(X)
+        AppleAccelerate.vclip!(Z, X, low, high)
+        @test Z ≈ clamp.(X, low, high)
+
+        # vthr
+        thr::T = T(0.0)
+        @test AppleAccelerate.vthr(X, thr) ≈ max.(X, thr)
+
+        # vthres
+        expected_vthres = [x >= thr ? x : T(0) for x in X]
+        @test AppleAccelerate.vthres(X, thr) ≈ expected_vthres
+    end
+end
+
+@testset "vDSP Type Conversion" begin
+    X32 = randn(Float32, N)
+    X64 = randn(Float64, N)
+
+    @test AppleAccelerate.vdouble(X32) ≈ Float64.(X32)
+    @test AppleAccelerate.vsingle(X64) ≈ Float32.(X64)
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Ramp::$T" begin
+        start::T = T(1.0)
+        step::T = T(0.5)
+        n = 100
+        ramp = AppleAccelerate.vramp(start, step, n)
+        expected = [start + i * step for i in 0:(n-1)]
+        @test ramp ≈ expected
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Integration::$T" begin
+        n = 101
+        X::Vector{T} = ones(T, n)
+        step::T = T(0.1)
+
+        # vtrapz: trapezoidal integration of constant 1 over [0, 10] should give cumulative
+        trapz = AppleAccelerate.vtrapz(X, step)
+        # Result has same length as X; trapz[1] = 0, trapz[end] ≈ (n-1)*step
+        @test trapz[1] ≈ T(0) atol=eps(T)
+        @test trapz[end] ≈ T((n - 1) * step) atol=T(0.01)
+
+        # vswsum: sliding window sum
+        X2::Vector{T} = ones(T, 20)
+        sw = AppleAccelerate.vswsum(X2, 5)
+        @test length(sw) == 16
+        @test all(x -> isapprox(x, T(5), atol=eps(T)), sw)
+
+        # vswmax: sliding window max
+        X3::Vector{T} = T.(collect(1:20))
+        swm = AppleAccelerate.vswmax(X3, 5)
+        @test length(swm) == 16
+        @test swm ≈ T.(collect(5:20))
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Interpolation::$T" begin
+        A::Vector{T} = randn(N)
+        B::Vector{T} = randn(N)
+        t::T = T(0.3)
+
+        # vintb: A + t*(B-A)
+        @test AppleAccelerate.vintb(A, B, t) ≈ A .+ t .* (B .- A)
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Polynomial::$T" begin
+        # Evaluate p(x) = 2x^2 + 3x + 1
+        # vDSP_vpoly uses coefficients in reverse order: [highest degree first]
+        # coeffs = [a_P, a_{P-1}, ..., a_1, a_0] for P-degree poly
+        coeffs::Vector{T} = T[2, 3, 1]
+        X::Vector{T} = T.(collect(-5.0:0.5:5.0))
+        result = AppleAccelerate.vpoly(coeffs, X)
+        expected = 2 .* X .^ 2 .+ 3 .* X .+ 1
+        @test result ≈ expected
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Normalization::$T" begin
+        X::Vector{T} = randn(N)
+        (result, m, s) = AppleAccelerate.vnormalize(X)
+        @test m ≈ Statistics.mean(X) atol=T(1e-4)
+        if s > 0
+            @test result ≈ (X .- m) ./ s atol=T(1e-3)
+        end
+    end
+end
+
+for T in (Float32, Float64)
+    @testset "vDSP Decibel Conversion::$T" begin
+        X::Vector{T} = abs.(randn(N)) .+ T(0.01)  # positive values
+        ref::T = T(1.0)
+
+        # Power: 10*log10(X/ref)
+        result_pow = AppleAccelerate.vdbcon(X, ref, true)
+        expected_pow = 10 .* log10.(X ./ ref)
+        @test result_pow ≈ expected_pow atol=T(1e-3)
+
+        # Amplitude: 20*log10(X/ref)
+        result_amp = AppleAccelerate.vdbcon(X, ref, false)
+        expected_amp = 20 .* log10.(X ./ ref)
+        @test result_amp ≈ expected_amp atol=T(1e-3)
+    end
+end
+
 end
 
 if AppleAccelerate.get_macos_version() < v"13.4"


### PR DESCRIPTION
## Summary
- Implements ~50 Tier 1/Tier 2 vDSP functions from #19: unary ops (`vneg`, `vnabs`, `vsq`, `vssq`, `vfrac`, `vabs`, `vreverse`), two-vector ops (`vmax`, `vmin`, `vmaxmg`, `vminmg`, `vdist`, `vtmerg`), scalar-vector divide (`svdiv`), compound arithmetic (`vam`, `vsbm`, `vaam`, `vsbsbm`, `vasbm`, `vpythg`, `vasm`, `vsbsm`, `vsma`, `vsmsa`, `vaddsub`, `venvlp`), reductions (`dot`, `distancesq`), clipping/thresholding (`vclip`, `viclip`, `vthr`, `vthres`, `vcmprs`), type conversion (`vdouble`, `vsingle`), ramp generation (`vramp`, `vrampmul`), integration (`vrsum`, `vsimps`, `vtrapz`, `vswsum`, `vswmax`), interpolation (`vintb`, `vlint`, `vqint`), polynomial evaluation (`vpoly`), normalization (`vnormalize`), zero crossings (`nzcros`), and decibel conversion (`vdbcon`)
- All functions support both Float32 and Float64 with in-place (`f!`) and allocating (`f`) variants
- Updated `docs/src/array.md` and `docs/src/api.md` with documentation for all new functions
- Fixed flaky QR sparse solve test by using N=100 with a diagonal shift for well-conditioned matrices

## Scope exclusions (future PRs)
- Complex-number variants (split-complex format)
- Stateful DSP: DFT, FIR, wiener, rfilter
- Spectral analysis: spectra, coherence, transferfunction

## Test plan
- [x] `julia +1.12 --project -e 'using Pkg; Pkg.test()'` — all tests pass locally
- [x] CI passes on macOS

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)