### PR TITLE
Add in-place FFT, real FFT, and clear errors for unsupported inputs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,7 +28,9 @@
 
 ## DSP & FFT
 
-- `fft`, `ifft`, `bfft`, `plan_fft` — FFT (Float32 and Float64, 1D and 2D)
+- `fft`, `ifft`, `bfft`, `fft!`, `ifft!`, `bfft!` — Complex FFT (Float32 and Float64, 1D and 2D)
+- `rfft`, `irfft`, `brfft` — Real FFT (Float32 and Float64, 1D)
+- `plan_fft`, `plan_rfft` — FFT plan creation
 - [`AppleAccelerate.plan_dct`](@ref), [`AppleAccelerate.dct`](@ref) — DCT (Float32 only)
 - `conv`, `conv!` — Convolution
 - `xcorr`, `xcorr!` — Cross-correlation

--- a/docs/src/dsp.md
+++ b/docs/src/dsp.md
@@ -8,7 +8,7 @@ using AppleAccelerate, AbstractFFTs
 
 ## FFT
 
-The FFT API follows the same naming conventions as [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl): `fft`, `ifft`, `bfft`, and `plan_fft`. Both 1D vectors and 2D matrices are supported with `ComplexF64` and `ComplexF32` inputs. All dimensions must be powers of 2.
+The FFT API follows the same naming conventions as [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl). Both 1D vectors and 2D matrices are supported with `ComplexF64` and `ComplexF32` inputs. All dimensions must be powers of 2.
 
 ```@example dsp
 x = randn(ComplexF64, 1024)
@@ -38,32 +38,69 @@ x2_recovered = AppleAccelerate.ifft(X2)
 nothing # hide
 ```
 
+### In-place FFT
+
+In-place variants avoid allocating the output array:
+
+```@example dsp
+x = randn(ComplexF64, 1024)
+y = copy(x)
+AppleAccelerate.fft!(y)       # forward, modifies y in-place
+AppleAccelerate.ifft!(y)      # inverse, modifies y in-place
+@assert y ≈ x
+nothing # hide
+```
+
+### Real FFT
+
+`rfft` computes the FFT of real input, returning only the non-redundant complex coefficients (length `N÷2+1`). `irfft` inverts it back to real output.
+
+```@example dsp
+x = randn(Float64, 1024)
+X = AppleAccelerate.rfft(x)          # Complex vector of length 513
+x_recovered = AppleAccelerate.irfft(X, 1024)  # Back to real, length 1024
+@assert x_recovered ≈ x
+nothing # hide
+```
+
 ### AbstractFFTs Integration
 
 AppleAccelerate provides a package extension for [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl), allowing you to use the standard Julia FFT interface backed by Apple's vDSP library. Load both packages to activate the extension:
 
 ```@example dsp
-# 1D FFT
 x = randn(ComplexF64, 1024)
+
+# Out-of-place
 X = fft(x)
 x_recovered = ifft(X)
 
-# 2D FFT
-x2 = randn(ComplexF64, 16, 32)
-X2 = fft(x2)
-x2_recovered = ifft(X2)
+# In-place
+y = copy(x)
+fft!(y)
+ifft!(y)
+@assert y ≈ x
 
-# Plan-based API (works for both 1D and 2D)
+# Plan-based API (works for all variants)
 p = plan_fft(x)
 X = p * x
 x_recovered = p \ X
 nothing # hide
 ```
 
-The extension supports `fft`, `ifft`, `bfft`, `plan_fft`, `plan_ifft`, `plan_bfft`, plan inversion via `inv(plan)`, and `mul!` for both 1D vectors and 2D matrices. Input must be `Vector{Complex{T}}` or `Matrix{Complex{T}}` with power-of-2 dimensions.
+The extension supports the full AbstractFFTs interface for 1D and 2D:
+
+| Function | Description |
+|----------|-------------|
+| `fft`, `ifft`, `bfft` | Out-of-place complex FFT |
+| `fft!`, `ifft!`, `bfft!` | In-place complex FFT |
+| `plan_fft`, `plan_ifft`, `plan_bfft` | Out-of-place plans |
+| `plan_fft!`, `plan_bfft!` | In-place plans |
+| `inv(plan)`, `p \\ x`, `mul!` | Plan operations |
+
+Input must be `Vector` or `Matrix` with `Complex{T}` elements and power-of-2 dimensions. Non-power-of-2 inputs, empty arrays, and 3D+ arrays will throw an `ArgumentError` with a message suggesting to use FFTW.jl.
 
 !!! note
-    In-place plans (`plan_fft!`, `plan_bfft!`) and real FFTs (`rfft`, `irfft`) are not supported since vDSP only provides out-of-place complex FFTs. 3D and higher-dimensional arrays are not supported by vDSP and will fall through to FFTW if available.
+    Real FFT (`rfft`, `irfft`, `brfft`) is available only via the direct `AppleAccelerate.*` API and is not wired into the AbstractFFTs extension, to avoid dispatch conflicts with other packages that call `rfft` internally on non-power-of-2 inputs.
 
 ## DCT (Discrete Cosine Transform)
 

--- a/ext/AppleAccelerateAbstractFFTsExt.jl
+++ b/ext/AppleAccelerateAbstractFFTsExt.jl
@@ -8,7 +8,44 @@ using LinearAlgebra
 using AppleAccelerate
 using AppleAccelerate: FFTSetup
 
-# Forward FFT plan wrapping vDSP
+# --- Validity checks ---
+# Used in plan creation to decide whether to use vDSP or fall through.
+_can_vdsp(x::AbstractVector) = length(x) > 0 && ispow2(length(x))
+function _can_vdsp(x::AbstractMatrix)
+    nrows, ncols = size(x)
+    nrows > 0 && ncols > 0 && ispow2(nrows) && ispow2(ncols)
+end
+_can_vdsp(x::AbstractArray) = false  # 3D+ not supported
+
+# Used in plan execution to guard against misuse of an existing plan.
+function _check_vdsp_fft(x::AbstractVector)
+    n = length(x)
+    n > 0 || throw(ArgumentError("input array must be non-empty"))
+    ispow2(n) || throw(ArgumentError("vDSP FFT requires power-of-2 length, got $n"))
+    return nothing
+end
+
+function _check_vdsp_fft(x::AbstractMatrix)
+    nrows, ncols = size(x)
+    nrows > 0 && ncols > 0 || throw(ArgumentError("input matrix must be non-empty"))
+    ispow2(nrows) || throw(ArgumentError("vDSP 2D FFT requires power-of-2 row count, got $nrows"))
+    ispow2(ncols) || throw(ArgumentError("vDSP 2D FFT requires power-of-2 column count, got $ncols"))
+    return nothing
+end
+
+# Error with a clear message when vDSP can't handle the input.
+function _vdsp_unsupported(x)
+    if ndims(x) > 2
+        throw(ArgumentError("vDSP only supports 1D and 2D FFTs (got $(ndims(x))D array). Use FFTW.jl for higher-dimensional transforms."))
+    elseif length(x) == 0
+        throw(ArgumentError("vDSP FFT requires non-empty arrays."))
+    else
+        throw(ArgumentError("vDSP FFT requires power-of-2 dimensions (got size $(size(x))). Use FFTW.jl for arbitrary sizes."))
+    end
+end
+
+# === Out-of-place plan types ===
+
 mutable struct VDSPFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
     setup::FFTSetup{T}
     sz::NTuple{N,Int}
@@ -19,7 +56,6 @@ mutable struct VDSPFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
     end
 end
 
-# Backward (unnormalized inverse) FFT plan wrapping vDSP
 mutable struct VDSPBFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
     setup::FFTSetup{T}
     sz::NTuple{N,Int}
@@ -36,50 +72,44 @@ Base.size(p::VDSPBFFTPlan) = p.sz
 AbstractFFTs.AdjointStyle(::VDSPFFTPlan) = AbstractFFTs.FFTAdjointStyle()
 AbstractFFTs.AdjointStyle(::VDSPBFFTPlan) = AbstractFFTs.FFTAdjointStyle()
 
-function _check_vdsp_fft(x::AbstractVector)
-    n = length(x)
-    n > 0 || throw(ArgumentError("input array must be non-empty"))
-    ispow2(n) || throw(ArgumentError("vDSP FFT requires power-of-2 length, got $n"))
-    return nothing
-end
+# --- Out-of-place plan creation (1D, 2D, N-d) ---
 
-function _check_vdsp_fft(x::AbstractMatrix)
-    nrows, ncols = size(x)
-    nrows > 0 && ncols > 0 || throw(ArgumentError("input matrix must be non-empty"))
-    ispow2(nrows) || throw(ArgumentError("vDSP 2D FFT requires power-of-2 row count, got $nrows"))
-    ispow2(ncols) || throw(ArgumentError("vDSP 2D FFT requires power-of-2 column count, got $ncols"))
-    return nothing
-end
-
-# 1D plans
 function AbstractFFTs.plan_fft(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
-    _check_vdsp_fft(x)
+    _can_vdsp(x) || _vdsp_unsupported(x)
     setup = FFTSetup{T}(length(x))
     VDSPFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_bfft(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
-    _check_vdsp_fft(x)
+    _can_vdsp(x) || _vdsp_unsupported(x)
     setup = FFTSetup{T}(length(x))
     VDSPBFFTPlan{T}(setup, size(x), region)
 end
 
-# 2D plans
 function AbstractFFTs.plan_fft(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
-    _check_vdsp_fft(x)
+    _can_vdsp(x) || _vdsp_unsupported(x)
     nrows, ncols = size(x)
     setup = FFTSetup{T}(max(nrows, ncols))
     VDSPFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_bfft(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
-    _check_vdsp_fft(x)
+    _can_vdsp(x) || _vdsp_unsupported(x)
     nrows, ncols = size(x)
     setup = FFTSetup{T}(max(nrows, ncols))
     VDSPBFFTPlan{T}(setup, size(x), region)
 end
 
-# 1D execution
+function AbstractFFTs.plan_fft(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
+    _vdsp_unsupported(x)
+end
+
+function AbstractFFTs.plan_bfft(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
+    _vdsp_unsupported(x)
+end
+
+# --- Out-of-place execution ---
+
 function Base.:*(p::VDSPFFTPlan{T,1}, x::AbstractVector) where {T}
     _check_vdsp_fft(x)
     AppleAccelerate.fft(convert(Vector{Complex{T}}, x), p.setup)
@@ -90,7 +120,6 @@ function Base.:*(p::VDSPBFFTPlan{T,1}, x::AbstractVector) where {T}
     AppleAccelerate.bfft(convert(Vector{Complex{T}}, x), p.setup)
 end
 
-# 2D execution
 function Base.:*(p::VDSPFFTPlan{T,2}, x::AbstractMatrix) where {T}
     _check_vdsp_fft(x)
     AppleAccelerate.fft(convert(Matrix{Complex{T}}, x), p.setup)
@@ -101,7 +130,8 @@ function Base.:*(p::VDSPBFFTPlan{T,2}, x::AbstractMatrix) where {T}
     AppleAccelerate.bfft(convert(Matrix{Complex{T}}, x), p.setup)
 end
 
-# 1D mul!
+# --- Out-of-place mul! ---
+
 function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
     _check_vdsp_fft(x)
     copyto!(y, AppleAccelerate.fft(convert(Vector{Complex{T}}, x), p.setup))
@@ -112,7 +142,6 @@ function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPBFFTPlan{T,1},
     copyto!(y, AppleAccelerate.bfft(convert(Vector{Complex{T}}, x), p.setup))
 end
 
-# 2D mul!
 function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
     _check_vdsp_fft(x)
     copyto!(y, AppleAccelerate.fft(convert(Matrix{Complex{T}}, x), p.setup))
@@ -123,6 +152,8 @@ function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPBFFTPlan{T,2},
     copyto!(y, AppleAccelerate.bfft(convert(Matrix{Complex{T}}, x), p.setup))
 end
 
+# --- Out-of-place plan_inv ---
+
 function AbstractFFTs.plan_inv(p::VDSPFFTPlan{T}) where {T}
     bplan = VDSPBFFTPlan{T}(p.setup, p.sz, p.region)
     N = AbstractFFTs.normalization(Complex{T}, p.sz, p.region)
@@ -132,6 +163,134 @@ end
 
 function AbstractFFTs.plan_inv(p::VDSPBFFTPlan{T}) where {T}
     fplan = VDSPFFTPlan{T}(p.setup, p.sz, p.region)
+    N = AbstractFFTs.normalization(Complex{T}, p.sz, p.region)
+    fplan.pinv = ScaledPlan(p, N)
+    ScaledPlan(fplan, N)
+end
+
+# === In-place plan types ===
+
+mutable struct VDSPInplaceFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
+    setup::FFTSetup{T}
+    sz::NTuple{N,Int}
+    region::G
+    pinv::Plan{Complex{T}}
+    function VDSPInplaceFFTPlan{T}(setup::FFTSetup{T}, sz::NTuple{N,Int}, region::G) where {T,N,G}
+        new{T,N,G}(setup, sz, region)
+    end
+end
+
+mutable struct VDSPInplaceBFFTPlan{T<:Union{Float32,Float64},N,G} <: Plan{Complex{T}}
+    setup::FFTSetup{T}
+    sz::NTuple{N,Int}
+    region::G
+    pinv::Plan{Complex{T}}
+    function VDSPInplaceBFFTPlan{T}(setup::FFTSetup{T}, sz::NTuple{N,Int}, region::G) where {T,N,G}
+        new{T,N,G}(setup, sz, region)
+    end
+end
+
+Base.size(p::VDSPInplaceFFTPlan) = p.sz
+Base.size(p::VDSPInplaceBFFTPlan) = p.sz
+
+AbstractFFTs.AdjointStyle(::VDSPInplaceFFTPlan) = AbstractFFTs.FFTAdjointStyle()
+AbstractFFTs.AdjointStyle(::VDSPInplaceBFFTPlan) = AbstractFFTs.FFTAdjointStyle()
+
+# --- In-place plan creation (1D, 2D, N-d) ---
+
+function AbstractFFTs.plan_fft!(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
+    _can_vdsp(x) || _vdsp_unsupported(x)
+    setup = FFTSetup{T}(length(x))
+    VDSPInplaceFFTPlan{T}(setup, size(x), region)
+end
+
+function AbstractFFTs.plan_bfft!(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
+    _can_vdsp(x) || _vdsp_unsupported(x)
+    setup = FFTSetup{T}(length(x))
+    VDSPInplaceBFFTPlan{T}(setup, size(x), region)
+end
+
+function AbstractFFTs.plan_fft!(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
+    _can_vdsp(x) || _vdsp_unsupported(x)
+    nrows, ncols = size(x)
+    setup = FFTSetup{T}(max(nrows, ncols))
+    VDSPInplaceFFTPlan{T}(setup, size(x), region)
+end
+
+function AbstractFFTs.plan_bfft!(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
+    _can_vdsp(x) || _vdsp_unsupported(x)
+    nrows, ncols = size(x)
+    setup = FFTSetup{T}(max(nrows, ncols))
+    VDSPInplaceBFFTPlan{T}(setup, size(x), region)
+end
+
+function AbstractFFTs.plan_fft!(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
+    _vdsp_unsupported(x)
+end
+
+function AbstractFFTs.plan_bfft!(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
+    _vdsp_unsupported(x)
+end
+
+# --- In-place execution ---
+
+function Base.:*(p::VDSPInplaceFFTPlan{T,1}, x::AbstractVector) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.fft!(convert(Vector{Complex{T}}, x), p.setup)
+end
+
+function Base.:*(p::VDSPInplaceBFFTPlan{T,1}, x::AbstractVector) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.bfft!(convert(Vector{Complex{T}}, x), p.setup)
+end
+
+function Base.:*(p::VDSPInplaceFFTPlan{T,2}, x::AbstractMatrix) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.fft!(convert(Matrix{Complex{T}}, x), p.setup)
+end
+
+function Base.:*(p::VDSPInplaceBFFTPlan{T,2}, x::AbstractMatrix) where {T}
+    _check_vdsp_fft(x)
+    AppleAccelerate.bfft!(convert(Matrix{Complex{T}}, x), p.setup)
+end
+
+# --- In-place mul! ---
+
+function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPInplaceFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, x)
+    AppleAccelerate.fft!(convert(Vector{Complex{T}}, y), p.setup)
+end
+
+function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPInplaceBFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, x)
+    AppleAccelerate.bfft!(convert(Vector{Complex{T}}, y), p.setup)
+end
+
+function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPInplaceFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, x)
+    AppleAccelerate.fft!(convert(Matrix{Complex{T}}, y), p.setup)
+end
+
+function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPInplaceBFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
+    _check_vdsp_fft(x)
+    copyto!(y, x)
+    AppleAccelerate.bfft!(convert(Matrix{Complex{T}}, y), p.setup)
+end
+
+# --- In-place plan_inv ---
+
+function AbstractFFTs.plan_inv(p::VDSPInplaceFFTPlan{T}) where {T}
+    bplan = VDSPInplaceBFFTPlan{T}(p.setup, p.sz, p.region)
+    N = AbstractFFTs.normalization(Complex{T}, p.sz, p.region)
+    bplan.pinv = ScaledPlan(p, N)
+    ScaledPlan(bplan, N)
+end
+
+function AbstractFFTs.plan_inv(p::VDSPInplaceBFFTPlan{T}) where {T}
+    fplan = VDSPInplaceFFTPlan{T}(p.setup, p.sz, p.region)
     N = AbstractFFTs.normalization(Complex{T}, p.sz, p.region)
     fplan.pinv = ScaledPlan(p, N)
     ScaledPlan(fplan, N)

--- a/src/DSP.jl
+++ b/src/DSP.jl
@@ -549,3 +549,278 @@ ifft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}
 ifft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = bfft(x, setup) ./ length(x)
 ifft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft(x, plan_fft(x))
 ifft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft(x, plan_fft(x))
+
+# --- Internal in-place 1D complex FFT ---
+
+function _fft1d!(x::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
+    n = length(x)
+    @assert ispow2(n) "length of input must be a power of 2"
+    logn = trailing_zeros(n)
+
+    realp = real.(x)
+    imagp = imag.(x)
+
+    GC.@preserve realp imagp begin
+        c = DSPDoubleSplitComplex(realp, imagp)
+        ccall(("vDSP_fft_zipD", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
+              setup.plan, c, SIGNAL_STRIDE, logn, direction)
+    end
+
+    @inbounds for i in eachindex(x)
+        x[i] = complex(realp[i], imagp[i])
+    end
+    return x
+end
+
+function _fft1d!(x::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int)
+    n = length(x)
+    @assert ispow2(n) "length of input must be a power of 2"
+    logn = trailing_zeros(n)
+
+    realp = Float32.(real.(x))
+    imagp = Float32.(imag.(x))
+
+    GC.@preserve realp imagp begin
+        c = DSPSplitComplex(realp, imagp)
+        ccall(("vDSP_fft_zip", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong, Culong, Cint),
+              setup.plan, c, SIGNAL_STRIDE, logn, direction)
+    end
+
+    @inbounds for i in eachindex(x)
+        x[i] = complex(realp[i], imagp[i])
+    end
+    return x
+end
+
+# --- Internal in-place 2D complex FFT ---
+
+function _fft2d!(x::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
+    nrows, ncols = size(x)
+    @assert ispow2(nrows) && ispow2(ncols) "dimensions must be powers of 2"
+    log2nr = trailing_zeros(nrows)
+    log2nc = trailing_zeros(ncols)
+
+    realp = real.(x)
+    imagp = imag.(x)
+
+    GC.@preserve realp imagp begin
+        c = DSPDoubleSplitComplex(pointer(realp), pointer(imagp))
+        ccall(("vDSP_fft2d_zipD", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong, Clong, Culong, Culong, Cint),
+              setup.plan, c, SIGNAL_STRIDE, 0, log2nr, log2nc, direction)
+    end
+
+    @inbounds for i in eachindex(x)
+        x[i] = complex(realp[i], imagp[i])
+    end
+    return x
+end
+
+function _fft2d!(x::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int)
+    nrows, ncols = size(x)
+    @assert ispow2(nrows) && ispow2(ncols) "dimensions must be powers of 2"
+    log2nr = trailing_zeros(nrows)
+    log2nc = trailing_zeros(ncols)
+
+    realp = Float32.(real.(x))
+    imagp = Float32.(imag.(x))
+
+    GC.@preserve realp imagp begin
+        c = DSPSplitComplex(pointer(realp), pointer(imagp))
+        ccall(("vDSP_fft2d_zip", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong, Clong, Culong, Culong, Cint),
+              setup.plan, c, SIGNAL_STRIDE, 0, log2nr, log2nc, direction)
+    end
+
+    @inbounds for i in eachindex(x)
+        x[i] = complex(realp[i], imagp[i])
+    end
+    return x
+end
+
+# --- Public API: fft! (in-place forward FFT) ---
+
+fft!(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d!(x, setup, FFT_FORWARD)
+fft!(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d!(x, setup, FFT_FORWARD)
+fft!(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = fft!(x, plan_fft(x))
+fft!(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = fft!(x, plan_fft(x))
+
+# --- Public API: bfft! (in-place backward/unnormalized inverse FFT) ---
+
+bfft!(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d!(x, setup, FFT_INVERSE)
+bfft!(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d!(x, setup, FFT_INVERSE)
+bfft!(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft!(x, plan_fft(x))
+bfft!(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft!(x, plan_fft(x))
+
+# --- Public API: ifft! (in-place normalized inverse FFT) ---
+
+function ifft!(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}}
+    bfft!(x, setup)
+    x ./= length(x)
+end
+function ifft!(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}}
+    bfft!(x, setup)
+    x ./= length(x)
+end
+ifft!(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft!(x, plan_fft(x))
+ifft!(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft!(x, plan_fft(x))
+
+# --- Internal 1D real FFT ---
+# vDSP real FFT uses packed split-complex format:
+#   Forward output: realp[0]=DC, imagp[0]=Nyquist, realp[k]+i*imagp[k] for k=1..N/2-1
+#   Forward scale: output is 2x the mathematical DFT
+# We unpack to standard format: Complex vector of length N/2+1
+
+function _rfft1d(x::Vector{Float64}, setup::FFTSetup{Float64})
+    n = length(x)
+    @assert ispow2(n) "length of input must be a power of 2"
+    logn = trailing_zeros(n)
+    half = n >> 1
+
+    # Pack real input into split-complex: realp[k]=x[2k-1], imagp[k]=x[2k] (1-based)
+    inp_realp = x[1:2:end]
+    inp_imagp = x[2:2:end]
+    out_realp = Vector{Float64}(undef, half)
+    out_imagp = Vector{Float64}(undef, half)
+
+    GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
+        input = DSPDoubleSplitComplex(inp_realp, inp_imagp)
+        output = DSPDoubleSplitComplex(out_realp, out_imagp)
+        ccall(("vDSP_fft_zropD", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong,
+               Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
+              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_FORWARD)
+    end
+
+    # Unpack and divide by 2 (vDSP scales forward real FFT by 2)
+    result = Vector{ComplexF64}(undef, half + 1)
+    result[1] = complex(out_realp[1] / 2, 0.0)
+    @inbounds for k in 2:half
+        result[k] = complex(out_realp[k] / 2, out_imagp[k] / 2)
+    end
+    result[half + 1] = complex(out_imagp[1] / 2, 0.0)
+    return result
+end
+
+function _rfft1d(x::Vector{Float32}, setup::FFTSetup{Float32})
+    n = length(x)
+    @assert ispow2(n) "length of input must be a power of 2"
+    logn = trailing_zeros(n)
+    half = n >> 1
+
+    inp_realp = Float32.(x[1:2:end])
+    inp_imagp = Float32.(x[2:2:end])
+    out_realp = Vector{Float32}(undef, half)
+    out_imagp = Vector{Float32}(undef, half)
+
+    GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
+        input = DSPSplitComplex(inp_realp, inp_imagp)
+        output = DSPSplitComplex(out_realp, out_imagp)
+        ccall(("vDSP_fft_zrop", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong,
+               Ref{DSPSplitComplex}, Clong, Culong, Cint),
+              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_FORWARD)
+    end
+
+    result = Vector{ComplexF32}(undef, half + 1)
+    result[1] = complex(out_realp[1] / 2, Float32(0))
+    @inbounds for k in 2:half
+        result[k] = complex(out_realp[k] / 2, out_imagp[k] / 2)
+    end
+    result[half + 1] = complex(out_imagp[1] / 2, Float32(0))
+    return result
+end
+
+# --- Internal 1D inverse real FFT (unnormalized) ---
+# Pack standard complex input back into vDSP format, run inverse, unpack real output.
+
+function _brfft1d(X::Vector{ComplexF64}, n::Int, setup::FFTSetup{Float64})
+    @assert ispow2(n) "output length must be a power of 2"
+    logn = trailing_zeros(n)
+    half = n >> 1
+    @assert length(X) == half + 1 "input must have length n÷2+1"
+
+    # Pack standard complex input into vDSP format
+    inp_realp = Vector{Float64}(undef, half)
+    inp_imagp = Vector{Float64}(undef, half)
+    inp_realp[1] = real(X[1])
+    inp_imagp[1] = real(X[half + 1])
+    @inbounds for k in 2:half
+        inp_realp[k] = real(X[k])
+        inp_imagp[k] = imag(X[k])
+    end
+
+    out_realp = Vector{Float64}(undef, half)
+    out_imagp = Vector{Float64}(undef, half)
+
+    GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
+        input = DSPDoubleSplitComplex(inp_realp, inp_imagp)
+        output = DSPDoubleSplitComplex(out_realp, out_imagp)
+        ccall(("vDSP_fft_zropD", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong,
+               Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
+              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_INVERSE)
+    end
+
+    # Unpack interleaved real output
+    result = Vector{Float64}(undef, n)
+    @inbounds for k in 1:half
+        result[2k - 1] = out_realp[k]
+        result[2k] = out_imagp[k]
+    end
+    return result
+end
+
+function _brfft1d(X::Vector{ComplexF32}, n::Int, setup::FFTSetup{Float32})
+    @assert ispow2(n) "output length must be a power of 2"
+    logn = trailing_zeros(n)
+    half = n >> 1
+    @assert length(X) == half + 1 "input must have length n÷2+1"
+
+    inp_realp = Vector{Float32}(undef, half)
+    inp_imagp = Vector{Float32}(undef, half)
+    inp_realp[1] = real(X[1])
+    inp_imagp[1] = real(X[half + 1])
+    @inbounds for k in 2:half
+        inp_realp[k] = real(X[k])
+        inp_imagp[k] = imag(X[k])
+    end
+
+    out_realp = Vector{Float32}(undef, half)
+    out_imagp = Vector{Float32}(undef, half)
+
+    GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
+        input = DSPSplitComplex(inp_realp, inp_imagp)
+        output = DSPSplitComplex(out_realp, out_imagp)
+        ccall(("vDSP_fft_zrop", libacc), Cvoid,
+              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong,
+               Ref{DSPSplitComplex}, Clong, Culong, Cint),
+              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_INVERSE)
+    end
+
+    result = Vector{Float32}(undef, n)
+    @inbounds for k in 1:half
+        result[2k - 1] = out_realp[k]
+        result[2k] = out_imagp[k]
+    end
+    return result
+end
+
+# --- Public API: rfft (forward real FFT) ---
+
+plan_rfft(x::Vector{T}) where {T<:Union{Float32,Float64}} = FFTSetup{T}(length(x))
+
+rfft(x::Vector{T}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _rfft1d(x, setup)
+rfft(x::Vector{T}) where {T<:Union{Float32,Float64}} = rfft(x, plan_rfft(x))
+
+# --- Public API: brfft (backward/unnormalized inverse real FFT) ---
+
+brfft(X::Vector{Complex{T}}, n::Int, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _brfft1d(X, n, setup)
+brfft(X::Vector{Complex{T}}, n::Int) where {T<:Union{Float32,Float64}} = brfft(X, n, FFTSetup{T}(n))
+
+# --- Public API: irfft (normalized inverse real FFT) ---
+
+irfft(X::Vector{Complex{T}}, n::Int, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = brfft(X, n, setup) ./ n
+irfft(X::Vector{Complex{T}}, n::Int) where {T<:Union{Float32,Float64}} = irfft(X, n, FFTSetup{T}(n))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,6 +290,92 @@ end
     end
 end
 
+@testset "fft! in-place" begin
+    for T in (ComplexF64, ComplexF32)
+        F = real(T)
+        @testset "1D $T" begin
+            for n in (16, 256, 1024)
+                x = randn(T, n)
+                expected = AppleAccelerate.fft(x)
+                y = copy(x)
+                AppleAccelerate.fft!(y)
+                if F == Float64
+                    @test y ≈ expected
+                else
+                    @test y ≈ expected rtol=sqrt(eps(Float32))
+                end
+            end
+        end
+        @testset "2D $T" begin
+            for (nr, nc) in ((4, 4), (8, 16))
+                x = randn(T, nr, nc)
+                expected = AppleAccelerate.fft(x)
+                y = copy(x)
+                AppleAccelerate.fft!(y)
+                if F == Float64
+                    @test y ≈ expected
+                else
+                    @test y ≈ expected rtol=sqrt(eps(Float32))
+                end
+            end
+        end
+    end
+end
+
+@testset "bfft! and ifft! in-place" begin
+    for T in (ComplexF64, ComplexF32)
+        F = real(T)
+        @testset "$T" begin
+            for n in (16, 256)
+                x = randn(T, n)
+                fwd = AppleAccelerate.fft(x)
+                y = copy(fwd)
+                AppleAccelerate.ifft!(y)
+                if F == Float64
+                    @test y ≈ x
+                else
+                    @test y ≈ x rtol=sqrt(eps(Float32))
+                end
+            end
+        end
+    end
+end
+
+@testset "rfft" begin
+    for T in (Float64, Float32)
+        @testset "$T" begin
+            for n in (16, 256, 1024)
+                x = randn(T, n)
+                result = AppleAccelerate.rfft(x)
+                expected = FFTW.rfft(x)
+                if T == Float64
+                    @test result ≈ expected
+                else
+                    @test result ≈ expected rtol=sqrt(eps(Float32))
+                end
+            end
+        end
+    end
+end
+
+@testset "brfft and irfft roundtrip" begin
+    for T in (Float64, Float32)
+        @testset "$T" begin
+            for n in (16, 256, 1024)
+                x = randn(T, n)
+                X = AppleAccelerate.rfft(x)
+                if T == Float64
+                    @test AppleAccelerate.brfft(X, n) ./ n ≈ x
+                    @test AppleAccelerate.irfft(X, n) ≈ x
+                else
+                    @test AppleAccelerate.brfft(X, n) ./ n ≈ x rtol=sqrt(eps(Float32))
+                    @test AppleAccelerate.irfft(X, n) ≈ x rtol=sqrt(eps(Float32))
+                end
+            end
+        end
+    end
+end
+
 @testset "AbstractFFTs extension" begin
     @testset "Forward FFT matches FFTW" begin
         for T in (ComplexF64, ComplexF32)
@@ -417,15 +503,37 @@ end
         @test p \ X ≈ x
     end
 
-    @testset "2D error cases" begin
+    @testset "Error cases" begin
+        # Non-power-of-2
+        @test_throws ArgumentError plan_fft(randn(ComplexF64, 100))
+        @test_throws ArgumentError fft(randn(ComplexF64, 100))
+        # Empty
+        @test_throws ArgumentError plan_fft(ComplexF64[])
+        # Non-power-of-2 2D
         @test_throws ArgumentError plan_fft(randn(ComplexF64, 3, 4))
         @test_throws ArgumentError plan_fft(randn(ComplexF64, 4, 6))
+        # 3D+ arrays
+        @test_throws ArgumentError plan_fft(randn(ComplexF64, 4, 4, 4))
+        @test_throws ArgumentError fft(randn(ComplexF64, 4, 4, 4))
+        @test_throws ArgumentError plan_fft!(randn(ComplexF64, 4, 4, 4))
     end
 
-    @testset "Error cases" begin
-        @test_throws ArgumentError plan_fft(randn(ComplexF64, 100))
-        @test_throws ArgumentError plan_fft(ComplexF64[])
+    @testset "In-place fft!" begin
+        x = randn(ComplexF64, 256)
+        p = plan_fft!(x)
+        y = copy(x)
+        p * y
+        @test y ≈ FFTW.fft(x)
     end
+
+    @testset "In-place ifft! roundtrip" begin
+        x = randn(ComplexF64, 256)
+        fwd = copy(x)
+        fft!(fwd)
+        ifft!(fwd)
+        @test fwd ≈ x
+    end
+
 end
 
 


### PR DESCRIPTION
## Summary

- Adds **in-place complex FFT** (`fft!`, `bfft!`, `ifft!`) for 1D vectors and 2D matrices using `vDSP_fft_zip`/`vDSP_fft2d_zip`
- Adds **real FFT** (`rfft`, `brfft`, `irfft`) for 1D vectors using `vDSP_fft_zrop`
- Wires in-place plans (`plan_fft!`, `plan_bfft!`) into the AbstractFFTs extension for 1D and 2D
- **Clear error messages** for unsupported inputs (non-power-of-2, empty, 3D+) suggesting FFTW.jl
- Real FFT (`rfft`/`irfft`/`brfft`) is available only via `AppleAccelerate.*` — not wired into the AbstractFFTs extension to avoid intercepting internal `rfft` calls from other packages on non-power-of-2 inputs

## Test plan

- [x] All 368 tests pass (0 errors)
- [x] In-place FFT: `fft!`/`bfft!`/`ifft!` roundtrip for ComplexF32/ComplexF64, 1D and 2D
- [x] Real FFT: `rfft` matches FFTW, `brfft`/`irfft` roundtrip for Float32/Float64
- [x] AbstractFFTs extension: `plan_fft`/`plan_fft!`/`fft`/`ifft` via standard interface
- [x] Error cases: non-power-of-2, empty, 3D arrays all throw `ArgumentError`
- [x] Conv/xcorr tests still pass (no dispatch conflict)
- [x] Docs build successfully with all `@example` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)