### PR TITLE
Only upload coverage from macOS CI runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
+        if: runner.os == 'macOS'
       - uses: codecov/codecov-action@v5
+        if: runner.os == 'macOS'
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Skip coverage processing and upload on non-macOS CI runners (ubuntu, windows)
- These platforms never load `src/Array.jl` or `src/DSP.jl` due to `if Sys.isapple()`, so they report 0% for all Accelerate-specific code and dilute the overall coverage numbers

## Test plan
- [x] CI passes (all 6 jobs green)
- [x] Codecov reports only reflect macOS coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)