### PR TITLE
Fix flaky sparse factorize test

### DIFF
--- a/test/libSparseTests.jl
+++ b/test/libSparseTests.jl
@@ -350,10 +350,11 @@ import AppleAccelerate: AASparseMatrix, muladd!, AAFactorization, solve, solve!,
         end
     end
     @testset "factorize" begin
-        jlM = sprand(4,4, .9)
+        # Use 100x100 to avoid singular matrices from small random sparse matrices
+        jlM = sprandn(100, 100, 0.3) + 10I
         aaM = AASparseMatrix(jlM)
         f = factorize(aaM)
-        b = rand(4)
+        b = rand(100)
         @test f \ b ≈ jlM \ b
     end
 end


### PR DESCRIPTION
## Summary

- The `factorize` test used `sprand(4,4, .9)` which can produce singular matrices, causing intermittent failures on Intel macOS CI
- Changed to `sprandn(100, 100, 0.3) + 10I` which is reliably non-singular due to the diagonal dominance

## Test plan

- [x] Reproduces: small 4x4 sparse random matrix can be singular
- [x] Fix: 100x100 with diagonal shift is always well-conditioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)