### PR TITLE
Fix all Aqua.jl quality issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "13e28ba4-7ad8-5781-acae-3021b1ed3924"
 version = "0.6.0"
 
 [deps]
-DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -16,24 +15,26 @@ AppleAccelerateAbstractFFTsExt = "AbstractFFTs"
 
 [compat]
 AbstractFFTs = "1.5"
+Aqua = "0.8"
 DSP = "0.8.4"
 FFTW = "1.10"
+Libdl = "1"
+LinearAlgebra = "1"
+Random = "1"
+SparseArrays = "1"
+Statistics = "1"
+Test = "1"
 julia = "1.10"
 
 [extras]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AbstractFFTs", "Dates", "Distributed", "FFTW", "Printf", "Random", "REPL", "Sockets", "SparseArrays", "SpecialFunctions", "DSP", "Statistics", "Test"]
+test = ["AbstractFFTs", "Aqua", "DSP", "FFTW", "Random", "SparseArrays", "Statistics", "Test"]

--- a/src/Array.jl
+++ b/src/Array.jl
@@ -117,7 +117,10 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
             Base.copyto!(dest::Array{$T, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T, N}}}) where {Style, Axes, N} = ($f!)(dest, bc.args...)
         end
         if T == Float32
-            @eval Base.broadcasted(::typeof($f), arg::Union{Array{F,N},Base.Broadcast.Broadcasted}) where {N,F<:Union{Float32,Float64}} = ($f)(maybecopy(arg))
+            @eval begin
+                Base.broadcasted(::typeof($f), arg::Array{<:Union{Float32,Float64}}) = ($f)(arg)
+                Base.broadcasted(::typeof($f), arg::Base.Broadcast.Broadcasted) = ($f)(copy(arg))
+            end
         end
     end
     for (f, fa) in (twoarg_funcs...,(:pow,:pow))
@@ -128,7 +131,12 @@ for (T, suff) in ((Float64, ""), (Float32, "f"))
             Base.copyto!(dest::Array{$T, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T,N},Array{$T,N}}}) where {Style, Axes, N} = ($f!)(dest, bc.args...)
         end
         if T == Float32
-            @eval Base.broadcasted(::typeof($f), arg1::Union{Array{F, N},Base.Broadcast.Broadcasted}, arg2::Union{Array{F, N},Base.Broadcast.Broadcasted}) where {N,F<:Union{Float32,Float64}} = ($f)(maybecopy(arg1), maybecopy(arg2))
+            @eval begin
+                Base.broadcasted(::typeof($f), arg1::Array{F}, arg2::Array{F}) where {F<:Union{Float32,Float64}} = ($f)(arg1, arg2)
+                Base.broadcasted(::typeof($f), arg1::Array{<:Union{Float32,Float64}}, arg2::Base.Broadcast.Broadcasted) = ($f)(arg1, copy(arg2))
+                Base.broadcasted(::typeof($f), arg1::Base.Broadcast.Broadcasted, arg2::Array{<:Union{Float32,Float64}}) = ($f)(copy(arg1), arg2)
+                Base.broadcasted(::typeof($f), arg1::Base.Broadcast.Broadcasted, arg2::Base.Broadcast.Broadcasted) = ($f)(copy(arg1), copy(arg2))
+            end
         end
     end
 end
@@ -205,9 +213,17 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             # Broadcasting override such that f.(X) turns into f(X)
             Base.copy(bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T, N},Array{$T,N}}}) where {Style, Axes, N} = ($f)(bc.args...)
             Base.copyto!(dest::Array{$T, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T,N},Array{$T,N}}}) where {Style, Axes, N} = ($f!)(dest, bc.args...)
-            Base.broadcasted(::typeof($f), arg1::Union{Array{$T, N},Base.Broadcast.Broadcasted}, arg2::Union{Array{$T, N},Base.Broadcast.Broadcasted}) where {N} = ($f)(maybecopy(arg1), maybecopy(arg2))
+            Base.broadcasted(::typeof($f), arg1::Array{$T}, arg2::Array{$T}) = ($f)(arg1, arg2)
+            Base.broadcasted(::typeof($f), arg1::Array{$T}, arg2::Base.Broadcast.Broadcasted) = ($f)(arg1, copy(arg2))
+            Base.broadcasted(::typeof($f), arg1::Base.Broadcast.Broadcasted, arg2::Array{$T}) = ($f)(copy(arg1), arg2)
         end
     end
+end
+
+# Disambiguating methods for (Broadcasted, Broadcasted) — resolves ambiguity between
+# Float32 and Float64 broadcasted overrides when both arguments are Broadcasted objects.
+for f in (:vadd, :vsub, :vmul, :vdiv)
+    @eval Base.broadcasted(::typeof($f), arg1::Base.Broadcast.Broadcasted, arg2::Base.Broadcast.Broadcasted) = ($f)(copy(arg1), copy(arg2))
 end
 
 # Element-wise operations over a vector and a scalar
@@ -315,7 +331,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             # Broadcasting override such that f.(X) turns into f(X)
             Base.copy(bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T, N},$T}}) where {Style, Axes, N} = ($f)(bc.args...)
             Base.copyto!(dest::Array{$T, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T,N},$T}}) where {Style, Axes, N} = ($f!)(dest, bc.args...)
-            Base.broadcasted(::typeof($f), arg1::Union{Array{$T, N},Base.Broadcast.Broadcasted}, arg2::$T) where {N} = ($f)(maybecopy(arg1), arg2)
+            Base.broadcasted(::typeof($f), arg1::Array{$T}, arg2::$T) = ($f)(arg1, arg2)
+            Base.broadcasted(::typeof($f), arg1::Base.Broadcast.Broadcasted, arg2::$T) = ($f)(copy(arg1), arg2)
         end
     end
 
@@ -326,7 +343,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         # Broadcasting override such that f.(X) turns into f(X)
         Base.copy(bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T, N}, $T}}) where {Style, Axes, N} = ($f)(bc.args...)
         Base.copyto!(dest::Array{$T, N}, bc::Base.Broadcast.Broadcasted{Style, Axes, typeof($f), Tuple{Array{$T,N}, $T}}) where {Style, Axes, N} = ($f!)(dest, bc.args...)
-        Base.broadcasted(::typeof($f), arg1::Union{Array{$T, N},Base.Broadcast.Broadcasted}, arg2::$T) where {N} = ($f)(maybecopy(arg1), arg2)
+        Base.broadcasted(::typeof($f), arg1::Array{$T}, arg2::$T) = ($f)(arg1, arg2)
+        Base.broadcasted(::typeof($f), arg1::Base.Broadcast.Broadcasted, arg2::$T) = ($f)(copy(arg1), arg2)
     end
 end
 

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -507,4 +507,25 @@ for T in (Float32, Float64)
     end
 end
 
+@testset "Broadcasted-Broadcasted dispatch" begin
+    # Test that binary vDSP ops correctly handle chained broadcasting
+    # where both arguments are Broadcasted objects (not yet materialized arrays).
+    # This exercises the disambiguating methods for vadd/vsub/vmul/vdiv.
+    for T in (Float32, Float64)
+        X = randn(T, N)
+        Y = randn(T, N)
+        A = randn(T, N)
+        B = randn(T, N)
+
+        # vadd.(abs.(X), abs.(Y)) — both args are Broadcasted
+        @test AppleAccelerate.vadd.(AppleAccelerate.abs.(X), AppleAccelerate.abs.(Y)) ≈ abs.(X) .+ abs.(Y)
+        # vsub
+        @test AppleAccelerate.vsub.(AppleAccelerate.abs.(X), AppleAccelerate.abs.(Y)) ≈ abs.(X) .- abs.(Y)
+        # vmul
+        @test AppleAccelerate.vmul.(AppleAccelerate.abs.(X), AppleAccelerate.abs.(Y)) ≈ abs.(X) .* abs.(Y)
+        # vdiv
+        @test AppleAccelerate.vdiv.(AppleAccelerate.abs.(X) .+ T(1), AppleAccelerate.abs.(Y) .+ T(1)) ≈ (abs.(X) .+ 1) ./ (abs.(Y) .+ 1)
+    end
+end
+
 end # @testset "Array Operations"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,15 @@ using LinearAlgebra
 using AppleAccelerate
 using AbstractFFTs
 using DSP, FFTW, Test, Random, Statistics
+using Aqua
 
 if !Sys.isapple()
     @info("AppleAccelerate.jl will be tested only on macOS. Exiting.")
     exit(0)
+end
+
+@testset "Aqua" begin
+    Aqua.test_all(AppleAccelerate)
 end
 
 Random.seed!(7)


### PR DESCRIPTION
## Summary

- **Unbound type parameters**: Split `Union{Array{..., N}, Broadcasted}` broadcasted overrides into separate methods for `Array` and `Broadcasted`, eliminating unbound `N` and `F` type parameters
- **Method ambiguities**: Add disambiguating `(Broadcasted, Broadcasted)` methods for two-argument vecLib and vDSP functions  
- **Stale dependency**: Remove `DSP` from `[deps]` (only used in tests, already in `[extras]`)
- **Compat bounds**: Add missing compat entries for stdlib deps (`Libdl`, `LinearAlgebra`, `SparseArrays`) and test extras (`Random`, `Statistics`, `Test`)
- **Unused extras**: Remove 6 unused test dependencies (`Dates`, `Distributed`, `Printf`, `REPL`, `Sockets`, `SpecialFunctions`)
- **Aqua test suite**: Add `Aqua.test_all(AppleAccelerate)` to CI
- **Dispatch tests**: Add tests verifying `Broadcasted-Broadcasted` dispatch for `vadd/vsub/vmul/vdiv`

## Test plan

- [x] All 11 Aqua checks pass locally
- [x] Existing array, DSP, sparse, and linalg tests pass
- [ ] CI passes on all macOS versions