### PR TITLE
Consistent testset names with doc sections

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,10 +16,7 @@ end
 Random.seed!(7)
 N = 1_000
 
-@testset "AppleAccelerate.jl" begin
-    include("array_tests.jl")
-    include("dsp_tests.jl")
-end
-
+include("array_tests.jl")
+include("dsp_tests.jl")
 include("sparse_tests.jl")
 include("linalg_tests.jl")

--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 
 import AppleAccelerate: AASparseMatrix, muladd!, AAFactorization, solve, solve!, factor!
 
-@testset "libSparse" begin
+@testset "Sparse Linear Algebra" begin
     @testset "wrappers" begin
         @testset "SparseMultiply and SparseMultiplyAdd" begin
             # less copy-paste heavy way via meta programming features?


### PR DESCRIPTION
## Summary

- Rename `"libSparse"` testset to `"Sparse Linear Algebra"` to match the doc page title
- Remove redundant `"AppleAccelerate.jl"` wrapper testset — each test file already defines its own top-level testset matching its doc section

Testset names now match doc pages:
| Test file | Testset name | Doc page |
|---|---|---|
| `array_tests.jl` | "Array Operations" | `array.md` |
| `dsp_tests.jl` | "Signal Processing" | `dsp.md` |
| `sparse_tests.jl` | "Sparse Linear Algebra" | `sparse.md` |
| `linalg_tests.jl` | "Dense Linear Algebra" | `blas.md` |

## Test plan

- [x] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)