### PR TITLE
Fall back to FFTW for FFT sizes vDSP can't handle (#139)

### DIFF
--- a/ext/AppleAccelerateAbstractFFTsExt.jl
+++ b/ext/AppleAccelerateAbstractFFTsExt.jl
@@ -44,6 +44,21 @@ function _vdsp_unsupported(x)
     end
 end
 
+# Is another AbstractFFTs backend (FFTW) loaded that we can hand off to?
+_other_fft_backend_loaded() = any(id.name == "FFTW" for id in keys(Base.loaded_modules))
+
+# vDSP only handles power-of-2 1D/2D transforms. For everything else (odd sizes,
+# 3D+, empty), defer to a general backend if one is loaded — `invoke` skips our
+# own (more specific) `Array{Complex}` methods and lands on FFTW's `StridedArray`
+# method, so loading AppleAccelerate no longer breaks generic `plan_fft` calls.
+# Without such a backend, raise the clear "use FFTW.jl" error.
+function _delegate_unsupported(planner, x, region; kwargs...)
+    _other_fft_backend_loaded() || _vdsp_unsupported(x)
+    return invoke(planner,
+                  Tuple{StridedArray{<:Union{ComplexF64,ComplexF32}}, typeof(region)},
+                  x, region; kwargs...)
+end
+
 # --- Region helpers ---
 # Normalize region to a Set of dimension indices.
 _region_set(region) = Set(collect(region))
@@ -96,37 +111,37 @@ AbstractFFTs.AdjointStyle(::VDSPBFFTPlan) = AbstractFFTs.FFTAdjointStyle()
 # --- Out-of-place plan creation (1D, 2D, N-d) ---
 
 function AbstractFFTs.plan_fft(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_fft, x, region; kwargs...)
     setup = FFTSetup{T}(length(x))
     VDSPFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_bfft(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_bfft, x, region; kwargs...)
     setup = FFTSetup{T}(length(x))
     VDSPBFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_fft(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_fft, x, region; kwargs...)
     nrows, ncols = size(x)
     setup = FFTSetup{T}(max(nrows, ncols))
     VDSPFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_bfft(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_bfft, x, region; kwargs...)
     nrows, ncols = size(x)
     setup = FFTSetup{T}(max(nrows, ncols))
     VDSPBFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_fft(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
-    _vdsp_unsupported(x)
+    _delegate_unsupported(AbstractFFTs.plan_fft, x, region; kwargs...)
 end
 
 function AbstractFFTs.plan_bfft(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
-    _vdsp_unsupported(x)
+    _delegate_unsupported(AbstractFFTs.plan_bfft, x, region; kwargs...)
 end
 
 # --- Out-of-place execution ---
@@ -238,37 +253,37 @@ AbstractFFTs.AdjointStyle(::VDSPInplaceBFFTPlan) = AbstractFFTs.FFTAdjointStyle(
 # --- In-place plan creation (1D, 2D, N-d) ---
 
 function AbstractFFTs.plan_fft!(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_fft!, x, region; kwargs...)
     setup = FFTSetup{T}(length(x))
     VDSPInplaceFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_bfft!(x::Vector{Complex{T}}, region=1:1; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_bfft!, x, region; kwargs...)
     setup = FFTSetup{T}(length(x))
     VDSPInplaceBFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_fft!(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_fft!, x, region; kwargs...)
     nrows, ncols = size(x)
     setup = FFTSetup{T}(max(nrows, ncols))
     VDSPInplaceFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_bfft!(x::Matrix{Complex{T}}, region=1:2; kwargs...) where {T<:Union{Float32,Float64}}
-    _can_vdsp(x) || _vdsp_unsupported(x)
+    _can_vdsp(x) || return _delegate_unsupported(AbstractFFTs.plan_bfft!, x, region; kwargs...)
     nrows, ncols = size(x)
     setup = FFTSetup{T}(max(nrows, ncols))
     VDSPInplaceBFFTPlan{T}(setup, size(x), region)
 end
 
 function AbstractFFTs.plan_fft!(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
-    _vdsp_unsupported(x)
+    _delegate_unsupported(AbstractFFTs.plan_fft!, x, region; kwargs...)
 end
 
 function AbstractFFTs.plan_bfft!(x::Array{Complex{T},N}, region=1:N; kwargs...) where {T<:Union{Float32,Float64},N}
-    _vdsp_unsupported(x)
+    _delegate_unsupported(AbstractFFTs.plan_bfft!, x, region; kwargs...)
 end
 
 # --- In-place execution ---

--- a/test/dsp_tests.jl
+++ b/test/dsp_tests.jl
@@ -334,19 +334,26 @@ end
         @test p \ X ≈ x
     end
 
-    @testset "Error cases" begin
-        # Non-power-of-2
-        @test_throws ArgumentError plan_fft(randn(ComplexF64, 100))
-        @test_throws ArgumentError fft(randn(ComplexF64, 100))
-        # Empty
-        @test_throws ArgumentError plan_fft(ComplexF64[])
-        # Non-power-of-2 2D
-        @test_throws ArgumentError plan_fft(randn(ComplexF64, 3, 4))
-        @test_throws ArgumentError plan_fft(randn(ComplexF64, 4, 6))
-        # 3D+ arrays
-        @test_throws ArgumentError plan_fft(randn(ComplexF64, 4, 4, 4))
-        @test_throws ArgumentError fft(randn(ComplexF64, 4, 4, 4))
-        @test_throws ArgumentError plan_fft!(randn(ComplexF64, 4, 4, 4))
+    @testset "Fallback to FFTW for unsupported sizes (#139)" begin
+        # vDSP only handles power-of-2 1D/2D transforms. With FFTW also loaded
+        # (as in this test environment), loading AppleAccelerate must NOT break
+        # generic `plan_fft`/`fft` for sizes vDSP can't do — they should defer
+        # to FFTW and return correct results rather than throwing.
+        for sz in (100, (3, 4), (4, 6), (4, 4, 4))
+            x = randn(ComplexF64, sz...)
+            @test fft(x) ≈ FFTW.fft(x)
+            @test plan_fft(x) * x ≈ FFTW.fft(x)
+            @test ifft(fft(x)) ≈ x
+        end
+        # In-place planning also delegates for non-power-of-2.
+        x = randn(ComplexF64, 8, 7)
+        @test (plan_fft!(copy(x)) * copy(x)) ≈ FFTW.fft(x)
+
+        # Power-of-2 sizes still use the vDSP path (acceleration preserved).
+        @test occursin("VDSP", string(nameof(typeof(plan_fft(randn(ComplexF64, 8, 8))))))
+
+        # Empty input has no valid transform; an error is still raised.
+        @test_throws Exception plan_fft(ComplexF64[])
     end
 
     @testset "In-place fft!" begin


### PR DESCRIPTION
Fixes #139.

## Problem

Loading AppleAccelerate broke generic FFT planning for any size vDSP can't handle:

```julia
julia> import FFTW, AppleAccelerate
julia> FFTW.plan_fft(rand(1024, 1023), flags=FFTW.MEASURE)
ERROR: ArgumentError: vDSP FFT requires power-of-2 dimensions (got size (1024, 1023)). Use FFTW.jl for arbitrary sizes.
```

## Root cause

The `AppleAccelerateAbstractFFTsExt` extension defines methods like `plan_fft(::Array{Complex{T},2}, region)`. These are **more specific** than FFTW's `plan_fft(::StridedArray{<:fftwComplex}, region)`, so they win dispatch even when the user calls `FFTW.plan_fft` (both resolve to the same `AbstractFFTs.plan_fft` generic). For non-power-of-2 / 3D+ inputs the methods then *threw*, instead of letting FFTW handle them. So merely loading AppleAccelerate hijacked—and broke—the standard FFT interface for arbitrary sizes.

## Fix

When vDSP can't handle the input, delegate to a general backend if one is loaded:

```julia
function _delegate_unsupported(planner, x, region; kwargs...)
    _other_fft_backend_loaded() || _vdsp_unsupported(x)
    return invoke(planner,
                  Tuple{StridedArray{<:Union{ComplexF64,ComplexF32}}, typeof(region)},
                  x, region; kwargs...)
end
```

`invoke` with the `StridedArray` signature skips our own (more specific) `Array{Complex}` methods and lands on FFTW's method, forwarding `region` and `kwargs` (e.g. `flags=FFTW.MEASURE`). Applied to all eight planners (`plan_fft`/`plan_bfft`/`plan_fft!`/`plan_bfft!`, 1D/2D and N-D).

- **Power-of-2 1D/2D** transforms still use the vDSP fast path (acceleration preserved).
- **Non-power-of-2, 3D+, and odd sizes** now defer to FFTW and return correct results.
- **No fallback backend loaded** → the clear `"...Use FFTW.jl for arbitrary sizes"` error is still raised.

## Tests

The former "Error cases" testset asserted these sizes throw. Since the test environment loads FFTW, they now correctly delegate, so it's replaced with a `Fallback to FFTW for unsupported sizes (#139)` testset that verifies: delegated results match `FFTW.fft` (odd 1D/2D and 3D), the round trip holds, in-place planning delegates, power-of-2 still uses a vDSP plan, and empty input still errors.

Full suite passes (Signal Processing +7 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)