### PR TITLE
Harden sparse factorization and solve safety

### DIFF
--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -169,6 +169,13 @@ function __init__()
         return
     end
     load_accelerate(; clear = false, load_ilp64=true)
+    # libSparse lives at a hard-coded path (LIBSPARSE in sparse.jl). Probe it once
+    # here so a future macOS layout change surfaces a clear diagnostic instead of
+    # an opaque dlopen error at the first sparse ccall.
+    if dlopen_e(LIBSPARSE) == C_NULL
+        @warn "AppleAccelerate.jl: libSparse could not be loaded from '$(LIBSPARSE)'; \
+               sparse linear algebra (AASparseMatrix, factorizations, solvers) will be unavailable"
+    end
 end
 
 @static if Sys.isapple()

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -49,7 +49,7 @@ end
 end
 
 @enum SparseScaling_t::UInt8 begin
-    SpraseScalingDefault = 0
+    SparseScalingDefault = 0
     SparseScalingUser = 1
     SparseScalingEquilibriationInf = 2
     # macOS 26+. Hungarian-and-ordering is only valid in a combined
@@ -148,7 +148,7 @@ end
 # For complex types, use the real-part's eps and precision tier.
 SparseNumericFactorOptions(T::Type) = SparseNumericFactorOptions(
     SparseDefaultControl,
-    SpraseScalingDefault,
+    SparseScalingDefault,
     C_NULL,
     real(T) == Float32 ? 0.1 : 0.01,
     eps(real(T))*1e-4
@@ -302,8 +302,6 @@ macro generateDemangled(jlName, cName, param, retType, jlArgTypes...)
     local jlCall = Expr(:(::), Expr(:call, esc(jlName), jlArgExprs...), retTypeWParam)
     # Build ccall directly instead of using @ccall macro to avoid variable name conflicts
     local cArgNames = [Symbol("arg$i") for i in 1:length(cArgTypesWParams)]
-    local LIBSPARSE = "/System/Library/Frameworks/Accelerate.framework/Versions"*
-                    "/A/Frameworks/vecLib.framework/libSparse.dylib"
     # Construct ccall((:cName, LIBSPARSE), retType, (argTypes...), args...)
     local cCallExpr = Expr(:call, :ccall,
                           Expr(:tuple, esc(cName), LIBSPARSE),
@@ -719,9 +717,28 @@ const _SOLVE_VEC_INPLACE_SYM = Dict(
 for (T, sym) in _SOLVE_VEC_INPLACE_SYM
     @eval function SparseSolve(arg1::SparseOpaqueFactorization{$T},
                                 arg2::StridedVector{$T})
+        nrows = Int(arg1.symbolicFactorization.rowCount)
+        ncols = Int(arg1.symbolicFactorization.columnCount)
+        # libSparse reads the RHS and writes the solution into the same buffer,
+        # which must therefore hold at least max(rows, cols) elements. Validate
+        # before the ccall so an undersized buffer can't be written out of bounds.
+        length(arg2) >= max(nrows, ncols) ||
+            throw(DimensionMismatch(
+                "in-place vector solve needs a buffer of at least " *
+                "max(rows, cols) = $(max(nrows, ncols)) elements; got $(length(arg2))"))
         @ccall LIBSPARSE.$sym(arg1::SparseOpaqueFactorization{$T},
                               arg2::DenseVector{$T})::Cvoid
-        resize!(arg2, arg1.symbolicFactorization.columnCount)
+        if length(arg2) != ncols
+            # Non-square system: trim the buffer down to the solution length.
+            # Only a real Vector can be resized; a view cannot.
+            arg2 isa Vector ||
+                throw(ArgumentError(
+                    "in-place solve of a non-square system needs a resizable " *
+                    "Vector RHS (got a $(typeof(arg2))); use the allocating " *
+                    "`solve`/`ldiv!(x, f, b)` instead"))
+            resize!(arg2, ncols)
+        end
+        return arg2
     end
 end
 
@@ -1036,8 +1053,19 @@ function factor!(aa_fact::AAFactorization{T},
                    (nrow == ncol && lu_ok)        ? SparseFactorizationLU :
                                                     SparseFactorizationQR
         end
-        aa_fact._factorization = SparseFactor(kind, aa_fact.matrixObj.matrix)
-        _libsparse_throw(aa_fact._factorization.status, "factor")
+        fact = SparseFactor(kind, aa_fact.matrixObj.matrix)
+        if fact.status == SparseStatusOk
+            aa_fact._factorization = fact
+        else
+            # The factorization failed (e.g. singular matrix). Free whatever
+            # SparseFactor allocated for the failed attempt, but leave the
+            # original yet-to-be-factored placeholder in place so (a) the
+            # finalizer never calls SparseCleanup on a non-Ok object and
+            # (b) a subsequent factor! retries instead of silently reusing a
+            # broken factorization.
+            SparseCleanup(fact)
+            _libsparse_throw(fact.status, "factor")
+        end
     end
 end
 

--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -325,7 +325,12 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, solve
                 factor!(f, AppleAccelerate.SparseFactorizationCholesky)
             catch err2
             end
-            @test err2 !== nothing
+            # Cholesky of a non-positive-definite matrix must raise, and the
+            # error should actually describe a factorization/property failure
+            # rather than being any arbitrary exception.
+            @test err2 isa Exception
+            @test occursin(r"properties|singular|factoriz|parameter|positive",
+                           lowercase(sprint(showerror, err2)))
 
             err3 = nothing
             nonSymmetric = sparse(temp*temp' + diagm(rand(N)) + singular)
@@ -449,7 +454,7 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, solve
             aa_fact = AAFactorization(tallMatrix)
             x, X = rand(3), rand(3, 3)
             b, B = tallMatrix * x, tallMatrix * X
-            @test isapprox(solve!(aa_fact, b), x; 0.001)
+            @test isapprox(solve!(aa_fact, b), x; atol=1e-3)
             # solve!(aa_fact, B)
             # @test isapprox(B, X; 0.001)
             shortMatrix = sprand(3,4,0.9)


### PR DESCRIPTION
## Summary
Correctness and memory-safety fixes in the `libSparse` wrappers, plus two test fixes.

### `factor!` caches failed factorizations (correctness + finalizer safety)
A failed factorization (e.g. singular matrix) was stored in the `AAFactorization` before the status was checked. Consequences:
- the finalizer would later call `SparseCleanup` on a non-`Ok` opaque object;
- a subsequent `factor!` saw a non-"yet-to-be-factored" status and **silently reused the broken factorization** (so a later `solve` used garbage).

Now the failed attempt is cleaned up immediately and the yet-to-be-factored placeholder is left in place, so a retry re-factors.

### In-place vector solve: out-of-bounds prevention
`SparseSolve(fact, ::StridedVector)` relied on a post-ccall `resize!` with no length validation. For an under-determined system the solution is longer than the RHS buffer → out-of-bounds write. Now it validates `length(rhs) ≥ max(rows, cols)` **before** the ccall, and gives a clear error when a non-resizable view is passed for a non-square system (instead of an opaque `resize!` failure).

### Smaller fixes
- Fix enum typo `SpraseScalingDefault` → `SparseScalingDefault`.
- Remove the duplicated hard-coded libSparse path literal inside `@generateDemangled` (reuse the `LIBSPARSE` const).
- Probe libSparse at `__init__` and warn clearly if it can't load, instead of an opaque dlopen error at first use.

### Tests
- **Silently-ignored tolerance:** `@test isapprox(solve!(...), x; 0.001)` — the bare `0.001` lands in the call's `parameters` block, and `@test`'s `isapprox` special-casing drops it, so the comparison ran at *default* tolerance. Changed to `atol=1e-3`.
- Strengthened the non-positive-definite Cholesky check from `err !== nothing` to assert it's an `Exception` describing a factorization/property failure.

### Follow-up (not in this PR)
The `SparseMatrix`/`AASparseMatrix` structs hold raw `pointer(...)` of their backing arrays and rely on the live Julia object to keep them rooted. That's currently safe (the matrix is always a live ccall argument) but fragile; wrapping the multiply/solve ccalls in explicit `GC.@preserve` is a worthwhile follow-up.

Full test suite passes locally on Apple Silicon (435 sparse assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)