### PR TITLE
Fix array.jl: svsub! temp alloc, maxvi/minvi index type, vsorti! docs

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -187,12 +187,12 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     for (f, fa) in ((:findmax, :maxvi), (:findmin, :minvi))
         @eval begin
             function ($f)(X::Vector{$T})
-                index = Ref{Int}(0)
+                index = Ref{UInt}(0)
                 val = Ref{$T}(0.0)
                 ccall(($(string("vDSP_", fa, suff), libacc)),  Cvoid,
-                      (Ptr{$T}, Int64,  Ref{$T}, Ref{Int}, UInt64),
+                      (Ptr{$T}, Int64,  Ref{$T}, Ref{UInt}, UInt64),
                       X, 1, val, index, length(X))
-                return (val[], index[]+1)
+                return (val[], Int(index[])+1)
             end
         end
     end
@@ -413,9 +413,10 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
         """ ->
         function ($f!)(result::Vector{$T}, X::Vector{$T}, c::$T)
-            ccall(($(string("vDSP_vsadd", suff), libacc)),  Cvoid,
-                    (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Int64,  UInt64),
-                    -X, 1, Ref(c), result, 1, length(result))
+            # c - X == X * (-1) + c, computed in one pass via vDSP_vsmsa (D = A*B + C)
+            ccall(($(string("vDSP_vsmsa", suff), libacc)),  Cvoid,
+                    (Ptr{$T}, Int64, Ptr{$T}, Ptr{$T}, Ptr{$T}, Int64,  UInt64),
+                    X, 1, Ref(-one($T)), Ref(c), result, 1, length(result))
             return result
         end
     end
@@ -1433,6 +1434,17 @@ end
 
 @doc "Sort vector in-place. `ascending=true` for ascending order. Wraps [`vDSP_vsort`](https://developer.apple.com/documentation/accelerate/vdsp_vsort)." vsort!
 @doc "Return sort permutation (1-based indices). Wraps [`vDSP_vsorti`](https://developer.apple.com/documentation/accelerate/vdsp_vsorti)." vsorti
+
+@doc """
+    vsorti!(indices::Vector{UInt}, X::Vector{T}, ascending::Bool=true)
+
+In-place index sort. `indices` MUST be pre-filled with the 0-based identity
+permutation `0:length(X)-1` before calling; `vDSP_vsorti` reorders those existing
+indices rather than generating them. Passing an uninitialized (`undef`) or otherwise
+non-identity buffer yields a silently wrong permutation. Use the allocating
+[`vsorti`](@ref) if you want the initialization handled for you. Wraps
+[`vDSP_vsorti`](https://developer.apple.com/documentation/accelerate/vdsp_vsorti).
+""" vsorti!
 
 # --- Table lookup ---
 for (T, suff) in ((Float32, ""), (Float64, "D"))

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -1019,6 +1019,23 @@ for T in (Float32, Float64)
         # vsorti
         perm = AppleAccelerate.vsorti(X, true)
         @test X[perm] ≈ sort(X)
+
+        # vsorti! directly, with the documented pre-filled 0-based identity
+        # buffer. The returned indices are 0-based; +1 gives a Julia permutation.
+        idx = UInt.(0:length(X)-1)
+        ret = AppleAccelerate.vsorti!(idx, X, true)
+        @test ret === idx                                 # mutates & returns same buffer
+        @test sort(Int.(idx)) == collect(0:length(X)-1)   # still a valid permutation
+        @test X[Int.(idx) .+ 1] ≈ sort(X)                 # and it actually sorts X
+
+        # descending
+        idx_desc = UInt.(0:length(X)-1)
+        AppleAccelerate.vsorti!(idx_desc, X, false)
+        @test sort(Int.(idx_desc)) == collect(0:length(X)-1)
+        @test X[Int.(idx_desc) .+ 1] ≈ sort(X, rev=true)
+
+        # vsorti! and the allocating vsorti must agree
+        @test (Int.(idx) .+ 1) == AppleAccelerate.vsorti(X, true)
     end
 end
 

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -168,6 +168,8 @@ for T in (Float32, Float64)
             @eval fa = AppleAccelerate.$f
             @test fa(X)[1] ≈ fb(X)[1]
             @test fa(X)[2] ≈ fb(X)[2]
+            # Public index return type must remain Int
+            @test typeof(fa(X)[2]) == Int
         end
 
         @testset "Testing meanmag::$T" begin
@@ -1183,6 +1185,35 @@ for T in (Float32, Float64)
 
         Y = AppleAccelerate.ztoc(re, im)
         @test Y ≈ X
+    end
+end
+
+# ============================================================
+# svsub correctness + edge cases
+# ============================================================
+for T in (Float32, Float64)
+    @testset "svsub correctness::$T" begin
+        X::Vector{T} = randn(N)
+        c::T = randn()
+
+        # Allocating svsub computes c - X
+        @test AppleAccelerate.svsub(X, c) ≈ (c .- X)
+
+        # Mutating svsub! matches allocating result
+        out = similar(X)
+        AppleAccelerate.svsub!(out, X, c)
+        @test out ≈ (c .- X)
+        @test out ≈ AppleAccelerate.svsub(X, c)
+
+        # In-place aliasing (out === X) works for a mutating op
+        Z = copy(X)
+        AppleAccelerate.vadd!(Z, Z, X)
+        @test Z ≈ (X .+ X)
+
+        # Single-element array
+        x1 = T[3]
+        @test AppleAccelerate.svsub(x1, T(5)) ≈ T[2]
+        @test AppleAccelerate.vadd(x1, x1) ≈ T[6]
     end
 end
 


### PR DESCRIPTION
Three focused fixes to `src/array.jl`, with tests in `test/array_tests.jl`.

## 1. `svsub!` no longer allocates a temporary every call
The mutating vector-scalar-subtract used `vDSP_vsadd` with `-X`, which materializes a `-X` array on every call. Replaced with `vDSP_vsmsa` (`D = A*B + C`), computing `c - X == X*(-1) + c` in a single pass with no temporary. Docstring meaning (`c - X`) unchanged.

## 2. `maxvi`/`minvi` index output type
`vDSP_maxvi`/`vDSP_minvi` write a `vDSP_Length` (unsigned). Changed the index `Ref{Int}` to `Ref{UInt}` for both the local buffer and the ccall arg type. The public return type is preserved: the index is converted back via `Int(index[])+1`, so `findmax`/`findmin` still return an `Int` index.

## 3. `vsorti!` documentation
`vsorti!(indices, X)` requires `indices` to be pre-filled with the 0-based identity permutation (`0:n-1`); `vDSP_vsorti` reorders those existing indices. Passing an `undef` buffer silently produces a wrong sort. Added an `@doc` note documenting this contract. Behavior unchanged (the allocating `vsorti` already initializes the buffer).

## Tests
- `svsub`/`svsub!` compute `c - X` for Float32 and Float64, allocating result matches mutating.
- Aliasing case (`vadd!(Z, Z, X)`) and single-element-array cases.
- `findmax`/`findmin` index is an `Int` (`typeof(...[2]) == Int`).

Full suite passes locally on Apple Silicon: `Testing AppleAccelerate tests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)