### PR TITLE
Ignore docs/build and .DS_Store artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 Manifest.toml
 *~
+docs/build/
+.DS_Store
+**/.DS_Store

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,13 +4,13 @@ using AbstractFFTs
 using DSP, FFTW, Random, Statistics, Test
 using Aqua
 
-@testset "Aqua" begin
-    Aqua.test_all(AppleAccelerate)
-end
-
 if !Sys.isapple()
     @info("AppleAccelerate.jl will be tested only on macOS. Exiting.")
     exit(0)
+end
+
+@testset "Aqua" begin
+    Aqua.test_all(AppleAccelerate)
 end
 
 Random.seed!(7)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,13 +4,13 @@ using AbstractFFTs
 using DSP, FFTW, Random, Statistics, Test
 using Aqua
 
+@testset "Aqua" begin
+    Aqua.test_all(AppleAccelerate)
+end
+
 if !Sys.isapple()
     @info("AppleAccelerate.jl will be tested only on macOS. Exiting.")
     exit(0)
-end
-
-@testset "Aqua" begin
-    Aqua.test_all(AppleAccelerate)
 end
 
 Random.seed!(7)


### PR DESCRIPTION
## Summary
Adds build/OS artifacts to `.gitignore`:

```
docs/build/
.DS_Store
**/.DS_Store
```

`docs/Manifest.toml` remains covered by the existing `Manifest.toml` rule.

The Aqua-on-all-CI-OSes change that was originally part of this PR has been reverted; this PR is now scoped to `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)