### PR TITLE
Fix concrete documentation review items

### DIFF
--- a/docs/src/array.md
+++ b/docs/src/array.md
@@ -502,6 +502,29 @@ AppleAccelerate.veqvi
 | signed int → float | `vflt8`, `vflt16`, `vflt32` | Signed integer to float |
 | unsigned int → float | `vfltu8`, `vfltu16`, `vfltu32` | Unsigned integer to float |
 
+Every function in this family has an allocating variant and a mutating variant
+`f!(C, A)` that writes into a preallocated `C`. The number in the name is the integer
+bit width (`8`, `16`, `32`), so `vfix32` truncates to `Int32`, `vfltu16` converts
+`UInt16` to float, and so on. Both `Float32` and `Float64` are supported.
+
+The two directions differ in how the output type is chosen. For **float → int** the
+integer type is fixed by the function name, so the allocating form is `f(A)`. For
+**int → float** the float width is ambiguous, so the allocating form takes it
+explicitly as `f(A, Float64)` (or `Float32`).
+
+```@example array
+X = Float64[-1.7, 0.4, 2.9]
+
+I32 = AppleAccelerate.vfix32(X)            # truncate toward zero → Int32[-1, 0, 2]
+R32 = AppleAccelerate.vfixr32(X)           # round to nearest    → Int32[-2, 0, 3]
+Xf  = AppleAccelerate.vflt32(I32, Float64) # back to Float64 (target type required)
+
+# Mutating variant writes into a preallocated output
+out = Vector{Int32}(undef, length(X))
+AppleAccelerate.vfix32!(out, X)
+nothing # hide
+```
+
 ## Image Convolution
 
 | Function | Description |

--- a/docs/src/filtering.md
+++ b/docs/src/filtering.md
@@ -42,9 +42,14 @@ AppleAccelerate.xcorr!
 
 Wraps [`vDSP_biquad`](https://developer.apple.com/documentation/accelerate/vdsp_biquad). IIR filtering via cascaded biquad sections. Both `Float64` and `Float32` processing are supported; coefficients are always `Float64`.
 
+Each section takes 5 coefficients in the order `[b0, b1, b2, a1, a2]` (feedforward
+then feedback). Use real filter-design coefficients rather than random values — an
+arbitrary `a1`/`a2` can place the poles outside the unit circle and make the filter
+unstable. The example below is a stable second-order lowpass:
+
 ```@example filtering
 X = randn(Float64, 100)
-coefficients = randn(5)  # 5 coefficients per section
+coefficients = [0.2929, 0.5858, 0.2929, 0.0, 0.1716]  # [b0, b1, b2, a1, a2]
 bq = AppleAccelerate.biquadcreate(coefficients, 1)  # defaults to Float64
 delays = zeros(4)
 result = AppleAccelerate.biquad(X, delays, length(X), bq)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/accelerate/), providing high-performance BLAS/LAPACK, vectorized math operations, DSP/FFT, and sparse linear algebra on macOS.
+A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/documentation/accelerate), providing high-performance BLAS/LAPACK, vectorized math operations, DSP/FFT, and sparse linear algebra on macOS.
 
 ## Installation
 


### PR DESCRIPTION
Fixes a few concrete issues found while reviewing the docs. Documentation-only — no source changes.

### Changes

- **Canonical Accelerate URL** (`index.md`): the intro linked the old `developer.apple.com/accelerate/` landing page while every other page uses `developer.apple.com/documentation/accelerate`. Made them consistent.

- **int↔float conversion family** (`array.md`): the `vfix*`/`vflt*` table listed function names but had no rendered docstrings (these are `@eval`-generated without docstrings, so a `@docs` block can't render them). Added prose documenting the uniform `f`/`f!` convention, the bit-width naming, and — importantly — the output-type asymmetry: float→int infers the int type from the name (`f(A)`), while int→float requires the float width explicitly (`f(A, Float64)`). Added a runnable, verified example.

- **Biquad example** (`filtering.md`): the example built a filter from `randn(5)` coefficients, which can place poles outside the unit circle and yield an unstable filter. Replaced with a fixed, stable second-order lowpass and documented the `[b0, b1, b2, a1, a2]` coefficient layout.

All new `@example` snippets were executed against the package and produce the output shown in their comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)