### PR TITLE
Complete LibAccelerate migration: split-complex & FFT internals

### DIFF
--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -1,29 +1,26 @@
 ## complexarray.jl — Complex-valued vDSP operations using split-complex format ##
 
-# NOTE ON THE RAW LAYER: the wrappers in this file are intentionally NOT migrated to
-# call the generated `LibAccelerate` submodule. They pass the split-complex operands
-# as `Ref{DSPSplitComplex}` / `Ref{DSPDoubleSplitComplex}` using the structs defined
-# below, whereas the generated `LibAccelerate.vDSP_z*` wrappers expect a
-# `Ptr{LibAccelerate.DSPSplitComplex}` built from LibAccelerate's own (nominally
-# distinct) struct type. A `Ref` to the local struct does not convert to a pointer to
-# the LibAccelerate struct, so a clean drop-in migration is not possible here without
-# reconstructing LibAccelerate's split-complex values. These remain direct `ccall`s.
+# RAW-LAYER MIGRATION NOTE: the split-complex wrappers in this file now call the
+# generated `LibAccelerate` submodule. The split-complex operands are passed as
+# `Ref{DSPSplitComplex}` / `Ref{DSPDoubleSplitComplex}`, which `@ccall` (inside the
+# generated wrappers) auto-converts to the `Ptr{DSPSplitComplex}` they expect.
+#
+# Previously this file defined its OWN `DSPSplitComplex` / `DSPDoubleSplitComplex`
+# structs that were distinct from LibAccelerate's, which is why #154 left these as raw
+# `ccall`s. We now ALIAS the names directly to `LibAccelerate.DSPSplitComplex` /
+# `LibAccelerate.DSPDoubleSplitComplex` (identical C layout: `{ Ptr realp; Ptr imagp }`),
+# so a `Ref` to one of them converts cleanly to the generated wrappers' pointer args.
+# The vector convenience constructors below are added as methods on the aliased types.
 
 # ============================================================
 # Split-complex structs (used here and by dsp.jl for FFT)
+# These alias the generated LibAccelerate structs so the generated `vDSP_z*` / FFT
+# wrappers accept `Ref`s to them with no conversion friction.
 # ============================================================
-struct DSPDoubleSplitComplex
-    realp::Ptr{Float64}
-    imagp::Ptr{Float64}
-end
+const DSPDoubleSplitComplex = LibAccelerate.DSPDoubleSplitComplex
+const DSPSplitComplex = LibAccelerate.DSPSplitComplex
 
 DSPDoubleSplitComplex(realp::Vector{Float64}, imagp::Vector{Float64}) = DSPDoubleSplitComplex(pointer(realp), pointer(imagp))
-
-struct DSPSplitComplex
-    realp::Ptr{Float32}
-    imagp::Ptr{Float32}
-end
-
 DSPSplitComplex(realp::Vector{Float32}, imagp::Vector{Float32}) = DSPSplitComplex(pointer(realp), pointer(imagp))
 
 # ------------------------------------------------------------
@@ -61,9 +58,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve X result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvneg", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      xsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvneg", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -81,9 +77,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve X result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvconj", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      xsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvconj", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -101,9 +96,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve X result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvmov", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      xsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvmov", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -140,9 +134,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 xsplit = _split_view($DSPSplit, pointer(X))
                 ysplit = _split_view($DSPSplit, pointer(Y))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvmul", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64, Cint),
-                      xsplit, _CSTRIDE, ysplit, _CSTRIDE, osplit, _CSTRIDE, n, Cint(1))
+                LibAccelerate.$(Symbol(string("vDSP_zvmul", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(ysplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n, Cint(1))
             end
             return result
         end
@@ -162,9 +155,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 xsplit = _split_view($DSPSplit, pointer(X))
                 ysplit = _split_view($DSPSplit, pointer(Y))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvdiv", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      ysplit, _CSTRIDE, xsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvdiv", suff)))(
+                      Ref(ysplit), _CSTRIDE, Ref(xsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -185,9 +177,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 xsplit = _split_view($DSPSplit, pointer(X))
                 csplit = _split_view($DSPSplit, pointer(c2))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvzsml", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Ref{$DSPSplit}, Int64, UInt64),
-                      xsplit, _CSTRIDE, csplit, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvzsml", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(csplit), Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -211,9 +202,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             n = length(X)
             GC.@preserve X result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
-                ccall(($(string("vDSP_zvabs", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, UInt64),
-                      xsplit, _CSTRIDE, result, 1, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvabs", suff)))(
+                      Ref(xsplit), _CSTRIDE, result, 1, n)
             end
             return result
         end
@@ -230,9 +220,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             n = length(X)
             GC.@preserve X result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
-                ccall(($(string("vDSP_zvphas", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, UInt64),
-                      xsplit, _CSTRIDE, result, 1, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvphas", suff)))(
+                      Ref(xsplit), _CSTRIDE, result, 1, n)
             end
             return result
         end
@@ -249,9 +238,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             n = length(X)
             GC.@preserve X result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
-                ccall(($(string("vDSP_zvmags", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, UInt64),
-                      xsplit, _CSTRIDE, result, 1, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvmags", suff)))(
+                      Ref(xsplit), _CSTRIDE, result, 1, n)
             end
             return result
         end
@@ -268,9 +256,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             n = length(X)
             GC.@preserve X B result begin
                 xsplit = _split_view($DSPSplit, pointer(X))
-                ccall(($(string("vDSP_zvmgsa", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
-                      xsplit, _CSTRIDE, B, 1, result, 1, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvmgsa", suff)))(
+                      Ref(xsplit), _CSTRIDE, B, 1, result, 1, n)
             end
             return result
         end
@@ -319,9 +306,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 xsplit = _split_view($DSPSplit, pointer(X))
                 ysplit = _split_view($DSPSplit, pointer(Y))
                 osplit = _split_view($DSPSplit, pointer(out))
-                ccall(($(string("vDSP_zdotpr", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, UInt64),
-                      xsplit, _CSTRIDE, ysplit, _CSTRIDE, osplit, n)
+                LibAccelerate.$(Symbol(string("vDSP_zdotpr", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(ysplit), _CSTRIDE, Ref(osplit), n)
             end
             return complex(out[1], out[2])
         end
@@ -340,9 +326,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             n = length(X)
             interleaved_out = Vector{$T}(undef, 2 * n)
             GC.@preserve X interleaved_out begin
-                ccall(($(string("vDSP_polar", suff)), libacc), Cvoid,
-                      (Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
-                      pointer(X), 2, interleaved_out, 2, n)
+                LibAccelerate.$(Symbol(string("vDSP_polar", suff)))(
+                      Ptr{$T}(pointer(X)), 2, interleaved_out, 2, n)
             end
             magnitudes = interleaved_out[1:2:end]
             angles = interleaved_out[2:2:end]
@@ -361,9 +346,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             interleaved_in[2:2:end] .= angles
             result = Vector{Complex{$T}}(undef, n)
             GC.@preserve interleaved_in result begin
-                ccall(($(string("vDSP_rect", suff)), libacc), Cvoid,
-                      (Ptr{$T}, Int64, Ptr{$T}, Int64, UInt64),
-                      interleaved_in, 2, pointer(result), 2, n)
+                LibAccelerate.$(Symbol(string("vDSP_rect", suff)))(
+                      interleaved_in, 2, Ptr{$T}(pointer(result)), 2, n)
             end
             return result
         end
@@ -402,9 +386,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 asplit = _split_view($DSPSplit, pointer(A))
                 bsplit = _split_view($DSPSplit, pointer(B))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvadd", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, bsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvadd", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -423,9 +406,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 asplit = _split_view($DSPSplit, pointer(A))
                 bsplit = _split_view($DSPSplit, pointer(B))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvsub", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, bsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvsub", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -444,9 +426,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 asplit = _split_view($DSPSplit, pointer(A))
                 bsplit = _split_view($DSPSplit, pointer(B))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvcmul", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, bsplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvcmul", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -466,9 +447,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve A B result begin
                 asplit = _split_view($DSPSplit, pointer(A))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zrvmul", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, B, 1, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zrvmul", suff)))(
+                      Ref(asplit), _CSTRIDE, B, 1, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -486,9 +466,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve A B result begin
                 asplit = _split_view($DSPSplit, pointer(A))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zrvdiv", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, B, 1, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zrvdiv", suff)))(
+                      Ref(asplit), _CSTRIDE, B, 1, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -506,9 +485,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve A B result begin
                 asplit = _split_view($DSPSplit, pointer(A))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zrvadd", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, B, 1, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zrvadd", suff)))(
+                      Ref(asplit), _CSTRIDE, B, 1, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -526,9 +504,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve A B result begin
                 asplit = _split_view($DSPSplit, pointer(A))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zrvsub", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, B, 1, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zrvsub", suff)))(
+                      Ref(asplit), _CSTRIDE, B, 1, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -550,9 +527,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 bsplit = _split_view($DSPSplit, pointer(B))
                 csplit = _split_view($DSPSplit, pointer(C))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvcma", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, bsplit, _CSTRIDE, csplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvcma", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(csplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -572,9 +548,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 bsplit = _split_view($DSPSplit, pointer(B))
                 csplit = _split_view($DSPSplit, pointer(C))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvma", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, bsplit, _CSTRIDE, csplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvma", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(csplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -595,9 +570,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 bsplit = _split_view($DSPSplit, pointer(b2))
                 csplit = _split_view($DSPSplit, pointer(C))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvsma", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      asplit, _CSTRIDE, bsplit, csplit, _CSTRIDE, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvsma", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), Ref(csplit), _CSTRIDE, Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -619,9 +593,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 asplit = _split_view($DSPSplit, pointer(A))
                 bsplit = _split_view($DSPSplit, pointer(B))
                 osplit = _split_view($DSPSplit, pointer(out))
-                ccall(($(string("vDSP_zidotpr", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, UInt64),
-                      asplit, _CSTRIDE, bsplit, _CSTRIDE, osplit, n)
+                LibAccelerate.$(Symbol(string("vDSP_zidotpr", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(osplit), n)
             end
             return complex(out[1], out[2])
         end
@@ -636,9 +609,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve A B out begin
                 asplit = _split_view($DSPSplit, pointer(A))
                 osplit = _split_view($DSPSplit, pointer(out))
-                ccall(($(string("vDSP_zrdotpr", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{$T}, Int64, Ref{$DSPSplit}, UInt64),
-                      asplit, _CSTRIDE, B, 1, osplit, n)
+                LibAccelerate.$(Symbol(string("vDSP_zrdotpr", suff)))(
+                      Ref(asplit), _CSTRIDE, B, 1, Ref(osplit), n)
             end
             return complex(out[1], out[2])
         end
@@ -654,9 +626,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             GC.@preserve result c2 begin
                 csplit = _split_view($DSPSplit, pointer(c2))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zvfill", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Ref{$DSPSplit}, Int64, UInt64),
-                      csplit, osplit, _CSTRIDE, n)
+                LibAccelerate.$(Symbol(string("vDSP_zvfill", suff)))(
+                      Ref(csplit), Ref(osplit), _CSTRIDE, n)
             end
             return result
         end
@@ -677,9 +648,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 xsplit = _split_view($DSPSplit, pointer(xpad))
                 ksplit = _split_view($DSPSplit, pointer(K))
                 osplit = _split_view($DSPSplit, pointer(result))
-                ccall(($(string("vDSP_zconv", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64, UInt64),
-                      xsplit, _CSTRIDE, ksplit, _CSTRIDE, osplit, _CSTRIDE, rn, kn)
+                LibAccelerate.$(Symbol(string("vDSP_zconv", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(ksplit), _CSTRIDE, Ref(osplit), _CSTRIDE, rn, kn)
             end
             return result
         end
@@ -704,9 +674,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                 bsplit = _split_view($DSPSplit, pointer(B))
                 osplit = _split_view($DSPSplit, pointer(C))
                 # Same trick as mmul: swap for col-major → row-major
-                ccall(($(string("vDSP_zmmul", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, Ref{$DSPSplit}, Int64, UInt64, UInt64, UInt64),
-                      bsplit, _CSTRIDE, asplit, _CSTRIDE, osplit, _CSTRIDE, UInt64(n), UInt64(m), UInt64(p))
+                LibAccelerate.$(Symbol(string("vDSP_zmmul", suff)))(
+                      Ref(bsplit), _CSTRIDE, Ref(asplit), _CSTRIDE, Ref(osplit), _CSTRIDE, UInt64(n), UInt64(m), UInt64(p))
             end
             return C
         end
@@ -747,9 +716,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             o_im = Vector{$T}(undef, n)
             GC.@preserve o_re o_im begin
                 osplit = $DSPSplit(o_re, o_im)
-                ccall(($(string("vDSP_ctoz", suff)), libacc), Cvoid,
-                      (Ptr{Complex{$T}}, Int64, Ref{$DSPSplit}, Int64, UInt64),
-                      X, 2, osplit, 1, n)
+                LibAccelerate.$(Symbol(string("vDSP_ctoz", suff)))(
+                      pointer(X), 2, Ref(osplit), 1, n)
             end
             return (o_re, o_im)
         end
@@ -758,9 +726,8 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             result = Vector{Complex{$T}}(undef, n)
             GC.@preserve re im begin
                 isplit = $DSPSplit(re, im)
-                ccall(($(string("vDSP_ztoc", suff)), libacc), Cvoid,
-                      (Ref{$DSPSplit}, Int64, Ptr{Complex{$T}}, Int64, UInt64),
-                      isplit, 1, result, 2, n)
+                LibAccelerate.$(Symbol(string("vDSP_ztoc", suff)))(
+                      Ref(isplit), 1, pointer(result), 2, n)
             end
             return result
         end

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -1,16 +1,21 @@
 ## dsp.jl ##
 #
-# RAW-LAYER MIGRATION NOTE: the real-valued vDSP wrappers here (conv, biquad /
-# biquadm, deq22, desamp, wiener, the *_window generators, and DCT/DFT execute /
-# destroy) now call the generated `LibAccelerate` submodule instead of embedding
-# `ccall` strings. Two groups are intentionally left as direct `ccall`s:
-#   1. Setup creators that return an opaque `Ptr{Cvoid}` (e.g. vDSP_*_CreateSetup,
-#      vDSP_create_fftsetup, vDSP_DFT_zop_CreateSetup): they have a non-`Cvoid`
-#      return and are kept as-is to avoid churn around the opaque handle types.
-#   2. Split-complex spectral / FFT routines (zaspec, zcoher, ztrans, zcspec and
-#      the fft_zop/zip/zrop family): these pass `Ref{DSPSplitComplex}` built from
-#      the local struct, which does not convert to the `Ptr{LibAccelerate struct}`
-#      the generated wrappers expect (same reason as complexarray.jl).
+# RAW-LAYER MIGRATION NOTE: the vDSP wrappers here now call the generated
+# `LibAccelerate` submodule instead of embedding `ccall` strings. This includes the
+# real-valued routines (conv, biquad / biquadm, deq22, desamp, wiener, the *_window
+# generators, DCT/DFT execute / destroy) AND, as of the complex/FFT migration, the
+# split-complex spectral routines (zaspec, zcoher, ztrans, zcspec) and the full FFT
+# family (fft_zop/zip/zrop, 1D and 2D, plus create/destroy_fftsetup). The
+# split-complex routines now pass `Ref{DSPSplitComplex}` / `Ref{DSPDoubleSplitComplex}`
+# built from the structs that `complexarray.jl` aliases directly to
+# `LibAccelerate.DSPSplitComplex` / `LibAccelerate.DSPDoubleSplitComplex`, so the
+# `Ref` converts cleanly to the `Ptr{DSPSplitComplex}` the generated wrappers expect.
+#
+# A few setup CREATORS are still direct `ccall`s on purpose: vDSP_DCT_CreateSetup and
+# vDSP_DFT_zop_CreateSetup{,D} return an opaque `Ptr{Cvoid}` and chain a `previous`
+# handle; they are kept as-is to avoid churn around the opaque handle types. (The FFT
+# setup creators ARE migrated, converting the generated `FFTSetup` pointer result back
+# to the `Ptr{Cvoid}` field type.)
 
 mutable struct DFTSetup{T}
     setup::Ptr{Cvoid}
@@ -399,9 +404,7 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
             imagp = $T.(imag.(A))
             GC.@preserve realp imagp begin
                 sc = $SC(pointer(realp), pointer(imagp))
-                ccall(($(string("vDSP_zaspec", suff)), libacc), Cvoid,
-                      (Ref{$SC}, Ptr{$T}, UInt64),
-                      sc, C, n)
+                LibAccelerate.$(Symbol(string("vDSP_zaspec", suff)))(Ref(sc), C, n)
             end
             return C
         end
@@ -423,9 +426,7 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
             ci = $T.(imag.(C))
             GC.@preserve cr ci begin
                 sc = $SC(pointer(cr), pointer(ci))
-                ccall(($(string("vDSP_zcoher", suff)), libacc), Cvoid,
-                      (Ptr{$T}, Ptr{$T}, Ref{$SC}, Ptr{$T}, UInt64),
-                      A, B, sc, D, n)
+                LibAccelerate.$(Symbol(string("vDSP_zcoher", suff)))(A, B, Ref(sc), D, n)
             end
             return D
         end
@@ -450,9 +451,7 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
             GC.@preserve br bi cr ci begin
                 scb = $SC(pointer(br), pointer(bi))
                 scc = $SC(pointer(cr), pointer(ci))
-                ccall(($(string("vDSP_ztrans", suff)), libacc), Cvoid,
-                      (Ptr{$T}, Ref{$SC}, Ref{$SC}, UInt64),
-                      A, scb, scc, n)
+                LibAccelerate.$(Symbol(string("vDSP_ztrans", suff)))(A, Ref(scb), Ref(scc), n)
             end
             @inbounds for i in 1:n
                 C[i] = complex(cr[i], ci[i])
@@ -483,9 +482,7 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
                 sca = $SC(pointer(ar), pointer(ai))
                 scb = $SC(pointer(br), pointer(bi))
                 scc = $SC(pointer(cr), pointer(ci))
-                ccall(($(string("vDSP_zcspec", suff)), libacc), Cvoid,
-                      (Ref{$SC}, Ref{$SC}, Ref{$SC}, UInt64),
-                      sca, scb, scc, n)
+                LibAccelerate.$(Symbol(string("vDSP_zcspec", suff)))(Ref(sca), Ref(scb), Ref(scc), n)
             end
             @inbounds for i in 1:n
                 C[i] = complex(cr[i], ci[i])
@@ -910,7 +907,7 @@ mutable struct FFTSetup{T}
     function FFTSetup{Float64}(n::Integer, radix::Integer = 2)
         @assert ispow2(n) "n must be a power of 2"
         logn = trailing_zeros(n)
-        plan = ccall(("vDSP_create_fftsetupD", libacc), Ptr{Cvoid}, (Culong, Cint), logn, radix)
+        plan = Ptr{Cvoid}(LibAccelerate.vDSP_create_fftsetupD(logn, radix))
         setup = new{Float64}(plan)
         finalizer(destroy_fftsetup, setup)
         setup
@@ -919,7 +916,7 @@ mutable struct FFTSetup{T}
     function FFTSetup{Float32}(n::Integer, radix::Integer = 2)
         @assert ispow2(n) "n must be a power of 2"
         logn = trailing_zeros(n)
-        plan = ccall(("vDSP_create_fftsetup", libacc), Ptr{Cvoid}, (Culong, Cint), logn, radix)
+        plan = Ptr{Cvoid}(LibAccelerate.vDSP_create_fftsetup(logn, radix))
         setup = new{Float32}(plan)
         finalizer(destroy_fftsetup, setup)
         setup
@@ -971,10 +968,8 @@ function _fft1d(r::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
     GC.@preserve realp imagp retr reti begin
         input = DSPDoubleSplitComplex(realp, imagp)
         output = DSPDoubleSplitComplex(retr, reti)
-        ccall(("vDSP_fft_zopD", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong,
-               Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, direction)
+        LibAccelerate.vDSP_fft_zopD(setup.plan, Ref(input), SIGNAL_STRIDE,
+                                    Ref(output), SIGNAL_STRIDE, logn, direction)
     end
 
     return complex.(retr, reti)
@@ -993,10 +988,8 @@ function _fft1d(r::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int)
     GC.@preserve realp imagp retr reti begin
         input = DSPSplitComplex(realp, imagp)
         output = DSPSplitComplex(retr, reti)
-        ccall(("vDSP_fft_zop", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong,
-               Ref{DSPSplitComplex}, Clong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, direction)
+        LibAccelerate.vDSP_fft_zop(setup.plan, Ref(input), SIGNAL_STRIDE,
+                                   Ref(output), SIGNAL_STRIDE, logn, direction)
     end
 
     return complex.(retr, reti)
@@ -1018,11 +1011,9 @@ function _fft2d(r::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
     GC.@preserve realp imagp retr reti begin
         input = DSPDoubleSplitComplex(pointer(realp), pointer(imagp))
         output = DSPDoubleSplitComplex(pointer(retr), pointer(reti))
-        ccall(("vDSP_fft2d_zopD", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong, Clong,
-               Ref{DSPDoubleSplitComplex}, Clong, Clong, Culong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, 0, output, SIGNAL_STRIDE, 0,
-              log2nr, log2nc, direction)
+        LibAccelerate.vDSP_fft2d_zopD(setup.plan, Ref(input), SIGNAL_STRIDE, 0,
+                                      Ref(output), SIGNAL_STRIDE, 0,
+                                      log2nr, log2nc, direction)
     end
 
     return complex.(retr, reti)
@@ -1042,11 +1033,9 @@ function _fft2d(r::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int)
     GC.@preserve realp imagp retr reti begin
         input = DSPSplitComplex(pointer(realp), pointer(imagp))
         output = DSPSplitComplex(pointer(retr), pointer(reti))
-        ccall(("vDSP_fft2d_zop", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong, Clong,
-               Ref{DSPSplitComplex}, Clong, Clong, Culong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, 0, output, SIGNAL_STRIDE, 0,
-              log2nr, log2nc, direction)
+        LibAccelerate.vDSP_fft2d_zop(setup.plan, Ref(input), SIGNAL_STRIDE, 0,
+                                     Ref(output), SIGNAL_STRIDE, 0,
+                                     log2nr, log2nc, direction)
     end
 
     return complex.(retr, reti)
@@ -1110,9 +1099,7 @@ function _fft1d!(x::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int
 
     GC.@preserve realp imagp begin
         c = DSPDoubleSplitComplex(realp, imagp)
-        ccall(("vDSP_fft_zipD", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
-              setup.plan, c, SIGNAL_STRIDE, logn, direction)
+        LibAccelerate.vDSP_fft_zipD(setup.plan, Ref(c), SIGNAL_STRIDE, logn, direction)
     end
 
     @inbounds for i in eachindex(x)
@@ -1131,9 +1118,7 @@ function _fft1d!(x::Vector{ComplexF32}, setup::FFTSetup{Float32}, direction::Int
 
     GC.@preserve realp imagp begin
         c = DSPSplitComplex(realp, imagp)
-        ccall(("vDSP_fft_zip", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong, Culong, Cint),
-              setup.plan, c, SIGNAL_STRIDE, logn, direction)
+        LibAccelerate.vDSP_fft_zip(setup.plan, Ref(c), SIGNAL_STRIDE, logn, direction)
     end
 
     @inbounds for i in eachindex(x)
@@ -1155,9 +1140,8 @@ function _fft2d!(x::Matrix{ComplexF64}, setup::FFTSetup{Float64}, direction::Int
 
     GC.@preserve realp imagp begin
         c = DSPDoubleSplitComplex(pointer(realp), pointer(imagp))
-        ccall(("vDSP_fft2d_zipD", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong, Clong, Culong, Culong, Cint),
-              setup.plan, c, SIGNAL_STRIDE, 0, log2nr, log2nc, direction)
+        LibAccelerate.vDSP_fft2d_zipD(setup.plan, Ref(c), SIGNAL_STRIDE, 0,
+                                      log2nr, log2nc, direction)
     end
 
     @inbounds for i in eachindex(x)
@@ -1177,9 +1161,8 @@ function _fft2d!(x::Matrix{ComplexF32}, setup::FFTSetup{Float32}, direction::Int
 
     GC.@preserve realp imagp begin
         c = DSPSplitComplex(pointer(realp), pointer(imagp))
-        ccall(("vDSP_fft2d_zip", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong, Clong, Culong, Culong, Cint),
-              setup.plan, c, SIGNAL_STRIDE, 0, log2nr, log2nc, direction)
+        LibAccelerate.vDSP_fft2d_zip(setup.plan, Ref(c), SIGNAL_STRIDE, 0,
+                                     log2nr, log2nc, direction)
     end
 
     @inbounds for i in eachindex(x)
@@ -1258,10 +1241,8 @@ function _rfft1d(x::Vector{Float64}, setup::FFTSetup{Float64})
     GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
         input = DSPDoubleSplitComplex(inp_realp, inp_imagp)
         output = DSPDoubleSplitComplex(out_realp, out_imagp)
-        ccall(("vDSP_fft_zropD", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong,
-               Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_FORWARD)
+        LibAccelerate.vDSP_fft_zropD(setup.plan, Ref(input), SIGNAL_STRIDE,
+                                     Ref(output), SIGNAL_STRIDE, logn, FFT_FORWARD)
     end
 
     # Unpack and divide by 2 (vDSP scales forward real FFT by 2)
@@ -1288,10 +1269,8 @@ function _rfft1d(x::Vector{Float32}, setup::FFTSetup{Float32})
     GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
         input = DSPSplitComplex(inp_realp, inp_imagp)
         output = DSPSplitComplex(out_realp, out_imagp)
-        ccall(("vDSP_fft_zrop", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong,
-               Ref{DSPSplitComplex}, Clong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_FORWARD)
+        LibAccelerate.vDSP_fft_zrop(setup.plan, Ref(input), SIGNAL_STRIDE,
+                                    Ref(output), SIGNAL_STRIDE, logn, FFT_FORWARD)
     end
 
     result = Vector{ComplexF32}(undef, half + 1)
@@ -1328,10 +1307,8 @@ function _brfft1d(X::Vector{ComplexF64}, n::Int, setup::FFTSetup{Float64})
     GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
         input = DSPDoubleSplitComplex(inp_realp, inp_imagp)
         output = DSPDoubleSplitComplex(out_realp, out_imagp)
-        ccall(("vDSP_fft_zropD", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPDoubleSplitComplex}, Clong,
-               Ref{DSPDoubleSplitComplex}, Clong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_INVERSE)
+        LibAccelerate.vDSP_fft_zropD(setup.plan, Ref(input), SIGNAL_STRIDE,
+                                     Ref(output), SIGNAL_STRIDE, logn, FFT_INVERSE)
     end
 
     # Unpack interleaved real output
@@ -1364,10 +1341,8 @@ function _brfft1d(X::Vector{ComplexF32}, n::Int, setup::FFTSetup{Float32})
     GC.@preserve inp_realp inp_imagp out_realp out_imagp begin
         input = DSPSplitComplex(inp_realp, inp_imagp)
         output = DSPSplitComplex(out_realp, out_imagp)
-        ccall(("vDSP_fft_zrop", libacc), Cvoid,
-              (Ptr{Cvoid}, Ref{DSPSplitComplex}, Clong,
-               Ref{DSPSplitComplex}, Clong, Culong, Cint),
-              setup.plan, input, SIGNAL_STRIDE, output, SIGNAL_STRIDE, logn, FFT_INVERSE)
+        LibAccelerate.vDSP_fft_zrop(setup.plan, Ref(input), SIGNAL_STRIDE,
+                                    Ref(output), SIGNAL_STRIDE, logn, FFT_INVERSE)
     end
 
     result = Vector{Float32}(undef, n)


### PR DESCRIPTION
Completes the internals migration started in #154; part of the LibAccelerate capability series (follow-up to #151).

#154 migrated `array.jl` and the real-valued parts of `dsp.jl` to the generated `LibAccelerate` raw layer, but deliberately left two groups as raw `ccall`s: the split-complex wrappers in `complexarray.jl`, and the split-complex / FFT routines in `dsp.jl`. This PR finishes them.

## What was migrated

**`src/complexarray.jl`** — every split-complex wrapper now calls `LibAccelerate.vDSP_*`:
`vneg/vconj/vcopy`, `vmul/vdiv/vsmul`, `vabs/vphase/vmags/vmagsa`, `dot`, `polar/rect`,
the Batch-5 ops (`zvadd/zvsub/zvcmul`, `zrvmul/zrvdiv/zrvadd/zrvsub`, `zvcma/zvma/zvsma`,
`zidotpr/zrdotpr`, `zvfill!`, `zconv`, `zmmul`), and the format converters `ctoz/ztoc`.

**`src/dsp.jl`** — the split-complex spectral routines (`zaspec`, `zcoher`, `ztrans`, `zcspec`)
and the full FFT family: `fft_zop`/`fft_zip`/`fft_zrop` (1D) and `fft2d_zop`/`fft2d_zip` (2D),
plus `create_fftsetup` / `destroy_fftsetup`.

## How the `DSPSplitComplex` duplication was resolved

`complexarray.jl` previously defined its OWN `DSPSplitComplex` / `DSPDoubleSplitComplex`
structs, distinct from the ones in the generated `LibAccelerate` submodule — so a `Ref` to a
local struct would not convert to the `Ptr{LibAccelerate.DSPSplitComplex}` the generated
wrappers expect. That was exactly the friction #154 cited.

Both structs mirror the same C layout (`{ Ptr realp; Ptr imagp }`), so the fix is to **alias**
the names directly:

```julia
const DSPDoubleSplitComplex = LibAccelerate.DSPDoubleSplitComplex
const DSPSplitComplex       = LibAccelerate.DSPSplitComplex
```

The `_split_view` helpers and the `Vector`-based convenience constructors are kept as methods on
the aliased types. With the names unified, `Ref(split)` converts cleanly to the generated
wrappers' pointer args, and `dsp.jl` (which reuses these struct names for FFT) gets the fix for
free. No external code referenced the local structs, so the alias keeps every name resolving and
the public API unchanged.

## ABI care (x86_64 risk)

Each generated signature was grepped from `src/lib/LibAccelerate.jl` and matched exactly —
respecting by-value vs by-pointer struct args (split-complex args are passed by **pointer** via
`Ref`, never by value), and the integer widths (`vDSP_Stride = Clong`, `vDSP_Length = Culong`).
This avoids the kind of pass-struct-by-value-where-a-pointer-was-wanted mismatch that can pass on
arm64 and SIGILL on Intel.

## Left as raw `ccall` (unchanged, with comments)

- **`cis` / `vvcosisin`** (`array.jl`): genuine generator typedef bug — the generated wrapper
  types its complex output as `Ptr{__double_complex_t}`, which Clang.jl resolves to `ComplexF32`
  even for the Float64 variant, so a `ComplexF64` output buffer won't convert. Kept raw per #154.
- **DCT/DFT `*_CreateSetup`** (`dsp.jl`): opaque `Ptr{Cvoid}` handles that chain a `previous`
  setup; left as-is to avoid churn around the opaque handle types (the same group-1 policy #154
  used; FFT setup creators, by contrast, are migrated).

## Verification

Full suite green on macOS arm64 / Julia 1.12 (`Pkg.test()`), including
`Complex Array Operations` and `Signal Processing` (FFT + spectral). No public API or numerical
behavior changed — internal refactor only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)