### PR TITLE
Make LinearAlgebra/SparseArrays weak deps; move integration into package extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,17 @@ version = "0.7.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extensions]
-AppleAccelerateAbstractFFTsExt = "AbstractFFTs"
+AppleAccelerateAbstractFFTsExt = ["AbstractFFTs", "LinearAlgebra"]
+AppleAccelerateLinearAlgebraExt = "LinearAlgebra"
+AppleAccelerateSparseArraysExt = "SparseArrays"
+AppleAccelerateLinearAlgebraSparseArraysExt = ["LinearAlgebra", "SparseArrays"]
 
 [compat]
 AbstractFFTs = "1.5"
@@ -31,10 +34,11 @@ AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AbstractFFTs", "Aqua", "DSP", "FFTW", "Random", "SparseArrays", "Statistics", "Test"]
+test = ["AbstractFFTs", "Aqua", "DSP", "FFTW", "LinearAlgebra", "Random", "SparseArrays", "Statistics", "Test"]

--- a/ext/AppleAccelerateLinearAlgebraExt.jl
+++ b/ext/AppleAccelerateLinearAlgebraExt.jl
@@ -1,0 +1,295 @@
+module AppleAccelerateLinearAlgebraExt
+
+@static if Sys.isapple()
+
+using Libdl
+using LinearAlgebra
+using AppleAccelerate
+using AppleAccelerate: libacc, vTypes,
+    AASparseMatrix, AAFactorization, SparseOpaqueFactorization, SparseMatrix,
+    SparseFactorization_t, SparseFactorizationTBD,
+    SparseFactorizationCholesky, SparseFactorizationLU, SparseFactorizationQR,
+    SparseStatus_t, SparseStatusOk, SparseMatrixIsSingular, SparseParameterError,
+    SparseStatusFailed, SparseInternalError, SparseYetToBeFactored,
+    SparseStatusReleased,
+    SparseFactor, SparseSolve, SparseCleanup,
+    SparseNumericFactorOptions, _sparse_refactor!, _refactor_family,
+    _is_symmetric_attr, _is_hermitian_attr, _is_triu_attr, _is_tril_attr,
+    get_macos_version, _macos_version
+
+import AppleAccelerate: factor!, solve, solve!, refactor!
+
+# ===========================================================================
+# BLAS/LAPACK forwarding to Accelerate (moved here from the core __init__)
+# ===========================================================================
+
+function AppleAccelerate.forward_accelerate(interface::Symbol;
+                            new_lapack::Bool = interface == :ilp64,
+                            clear::Bool = false,
+                            verbose::Bool = false)
+    kwargs = Dict{Symbol,String}()
+    if new_lapack
+        if interface == :ilp64
+            kwargs[:suffix_hint] = "\x1a\$NEWLAPACK\$ILP64"
+        else
+            kwargs[:suffix_hint] = "\x1a\$NEWLAPACK"
+        end
+    else
+        if interface == :ilp64
+            throw(ArgumentError("ILP64 accelerate requires new_lapack"))
+        end
+    end
+    BLAS.lbt_forward(libacc; clear, verbose, kwargs...)
+end
+
+function AppleAccelerate.load_accelerate(; clear::Bool = false,
+                           verbose::Bool = false,
+                           load_ilp64::Bool = true)
+    libacc_hdl = Libdl.dlopen_e(libacc)
+    if libacc_hdl == C_NULL
+        return
+    end
+
+    # Check to see if we can load ILP64 symbols
+    if load_ilp64 && Libdl.dlsym_e(libacc_hdl, "dgemm\$NEWLAPACK\$ILP64") == C_NULL
+        error("Unable to load ILP64 interface from '$(libacc)'; you are running macOS $(get_macos_version()), you need v13.4+")
+    end
+
+    # First, load :lp64 symbols, optionally clearing the current LBT forwarding tables
+    AppleAccelerate.forward_accelerate(:lp64; new_lapack=true, clear, verbose)
+    if load_ilp64
+        AppleAccelerate.forward_accelerate(:ilp64; new_lapack=true, verbose)
+    end
+end
+
+# ===========================================================================
+# AASparseMatrix predicates (delegate to core attribute-bit helpers)
+# ===========================================================================
+
+LinearAlgebra.issymmetric(M::AASparseMatrix) = _is_symmetric_attr(M)
+LinearAlgebra.ishermitian(M::AASparseMatrix) = _is_hermitian_attr(M)
+LinearAlgebra.istriu(M::AASparseMatrix) = _is_triu_attr(M)
+LinearAlgebra.istril(M::AASparseMatrix) = _is_tril_attr(M)
+
+# ===========================================================================
+# The factorize/solve subsystem on the core `AAFactorization` type
+# ===========================================================================
+#
+# `AAFactorization` is defined in core (src/sparse.jl) as a plain struct so that
+# the dual LinearAlgebra+SparseArrays extension can add a `SparseMatrixCSC`
+# constructor for it. Core deliberately does NOT subtype
+# `LinearAlgebra.Factorization` (no LinearAlgebra dependency). This extension
+# supplies the full `Factorization`-style API, including the `Base.:\` method
+# that the `Factorization` supertype would otherwise have provided.
+
+LinearAlgebra.factorize(A::AASparseMatrix{T}) where T<:vTypes = AAFactorization(A)
+
+# easiest way to make this follow the defaults and naming conventions of LinearAlgebra?
+"""
+    factor!(f::AAFactorization, [type::SparseFactorization_t])
+
+Explicitly compute the factorization. If `type` is not specified, the default
+is chosen from the matrix's kind attribute:
+
+  - Hermitian (real symmetric or complex Hermitian) → Cholesky
+  - square, non-Hermitian → LU (macOS 15.5+; falls back to QR on older systems)
+  - rectangular → QR
+
+Called automatically by [`solve`](@ref) if the factorization has not yet been
+computed.
+
+!!! note "Complex symmetric (not Hermitian)"
+    When the user leaves the factorization type unspecified and passes
+    a complex symmetric (but not Hermitian) matrix, we default to LU factorization.
+
+    On older versions of MacOS, Apple's `SparseFactorizationLDLT` errors on complex
+    symmetric (non-Hermitian) matrices, reporting "Cannot
+    perform Hermitian matrix factorization of non-Hermitian matrix."
+    On newer versions, it accepts the call and performs a true `LDLᵀ` (not `LDLᴴ`).
+    This behavior isn't documented by Apple; the exact version threshold is
+    unknown.
+"""
+function factor!(aa_fact::AAFactorization{T},
+            kind::SparseFactorization_t = SparseFactorizationTBD) where T<:vTypes
+    if aa_fact._factorization.status == SparseYetToBeFactored
+        if kind == SparseFactorizationTBD
+            # Cholesky for Hermitian (incl. real symmetric); LU for square
+            # non-Hermitian (macOS 15.5+); QR otherwise.
+            nrow, ncol = size(aa_fact.matrixObj)
+            lu_ok = something(_macos_version[], v"0.0.0") >= v"15.5"
+            kind = _is_hermitian_attr(aa_fact.matrixObj) ? SparseFactorizationCholesky :
+                   (nrow == ncol && lu_ok)               ? SparseFactorizationLU :
+                                                           SparseFactorizationQR
+        end
+        fact = SparseFactor(kind, aa_fact.matrixObj.matrix)
+        if fact.status == SparseStatusOk
+            aa_fact._factorization = fact
+        else
+            # The factorization failed (e.g. singular matrix). Free whatever
+            # SparseFactor allocated for the failed attempt, but leave the
+            # original yet-to-be-factored placeholder in place so (a) the
+            # finalizer never calls SparseCleanup on a non-Ok object and
+            # (b) a subsequent factor! retries instead of silently reusing a
+            # broken factorization.
+            SparseCleanup(fact)
+            _libsparse_throw(fact.status, "factor")
+        end
+    end
+end
+
+# Translate a libSparse status code into a typed Julia exception. SparseStatusOk
+# is a no-op so callers can write `_libsparse_throw(result.status, ...)` after
+# every libSparse call without branching.
+function _libsparse_throw(status::SparseStatus_t, op::AbstractString)
+    status == SparseStatusOk && return
+    status == SparseMatrixIsSingular &&
+        throw(LinearAlgebra.SingularException(0))
+    status == SparseParameterError &&
+        throw(ArgumentError("libSparse $(op) failed: parameter error " *
+            "(possibly: matrix lacks the properties required by this factorization, " *
+            "or factorization is unavailable on this macOS version)"))
+    status == SparseStatusFailed &&
+        error("libSparse $(op) failed (check that the matrix has the correct " *
+              "properties for this factorization)")
+    status == SparseInternalError &&
+        error("libSparse $(op) failed: internal error")
+    error("libSparse $(op) failed: status=$(status)")
+end
+
+"""
+    solve(f::AAFactorization, b::StridedVecOrMat)
+
+Solve the linear system `Ax = b` using Apple's Sparse Solvers, returning the solution `x`.
+The factorization is computed lazily on the first call if not already factored.
+Equivalent to `f \\ b`.
+"""
+function solve(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T}) where T<:vTypes
+    size(aa_fact.matrixObj)[1] != size(b, 1) && throw(DimensionMismatch(
+        "Matrix and right-hand side size mismatch: got "
+        * "$(size(aa_fact.matrixObj)[1]) and $(size(b, 1))"))
+    factor!(aa_fact)
+    x = Array{T}(undef, size(aa_fact.matrixObj)[2], size(b)[2:end]...)
+    SparseSolve(aa_fact._factorization, b, x)
+    return x
+end
+
+"""
+    solve!(f::AAFactorization, xb::StridedVecOrMat)
+
+Solve the linear system `Ax = b` in-place, overwriting `xb` with the solution.
+On input `xb` contains the right-hand side `b`; on output it contains the solution `x`.
+Equivalent to `ldiv!(f, xb)`.
+"""
+function solve!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vTypes
+    ((xb isa StridedMatrix) &&
+        (size(aa_fact.matrixObj)[1] != size(aa_fact.matrixObj)[2])) &&
+        throw(ArgumentError("Can't in-place " *
+                "solve: x and b are different sizes and Julia cannot resize a matrix."
+            )
+        )
+    factor!(aa_fact)
+    SparseSolve(aa_fact._factorization, xb)
+    return xb # written in imitation of KLU.jl, which also returns
+end
+
+# `\` would normally come from `AAFactorization <: LinearAlgebra.Factorization`,
+# but core keeps the type free of any LinearAlgebra dependency, so define it here.
+Base.:\(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T}) where T<:vTypes =
+        solve(aa_fact, b)
+
+LinearAlgebra.ldiv!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vTypes =
+        solve!(aa_fact, xb)
+
+function LinearAlgebra.ldiv!(x::StridedVecOrMat{T},
+                            aa_fact::AAFactorization{T},
+                            b::StridedVecOrMat{T}) where T<:vTypes
+    size(aa_fact.matrixObj)[1] != size(b, 1) && throw(DimensionMismatch(
+        "Matrix and right-hand side size mismatch: got "
+        * "$(size(aa_fact.matrixObj)[1]) and $(size(b, 1))"))
+    size(aa_fact.matrixObj)[2] != size(x, 1) && throw(DimensionMismatch(
+        "Matrix and output size mismatch: got "
+        * "$(size(aa_fact.matrixObj)[2]) and $(size(x, 1))"))
+    factor!(aa_fact)
+    SparseSolve(aa_fact._factorization, b, x)
+    return x
+end
+
+# ===========================================================================
+# refactor! (numeric refactor reusing a symbolic factorization)
+# ===========================================================================
+
+"""
+    refactor!(f::AAFactorization, A::AASparseMatrix)
+    refactor!(f::AAFactorization, A::SparseMatrixCSC)
+
+Recompute the numeric factorization stored in `f` using the values of `A`,
+**reusing the existing symbolic factorization** (the fill-reducing ordering and
+sparsity analysis). `A` must have the **same sparsity pattern** as the matrix
+`f` was originally factored from; only its numeric values may differ.
+
+This is substantially cheaper than building a fresh [`AAFactorization`](@ref)
+whenever a matrix changes values but not structure — the common case in Newton
+iterations, implicit time stepping, and parameter sweeps.
+
+`f` must already hold a completed factorization (call [`factor!`](@ref) or
+[`solve`](@ref) at least once first); otherwise an `ArgumentError` is thrown.
+The factorization object `f` is mutated in place and returned. After
+`refactor!`, `f` references `A`'s data, so keep `A` alive as long as `f` is used.
+
+!!! warning
+    Apple's libSparse does not validate that the new pattern matches the old
+    one. Passing a matrix with a different sparsity pattern is undefined
+    behavior. The dimensions and stored nonzero count are checked here as a
+    cheap guard, but an identical count with a different pattern will not be
+    caught.
+"""
+function refactor!(aa_fact::AAFactorization{T}, A::AASparseMatrix{T}) where T<:vTypes
+    status = aa_fact._factorization.status
+    status == SparseStatusOk || throw(ArgumentError(
+        "refactor! requires an already-computed factorization; call factor! or " *
+        "solve first (current status: $status)"))
+    old = aa_fact.matrixObj
+    size(old) == size(A) || throw(DimensionMismatch(
+        "refactor! requires matching dimensions: factored matrix is $(size(old)), " *
+        "new matrix is $(size(A))"))
+    length(old._nzval) == length(A._nzval) || throw(ArgumentError(
+        "refactor! requires the same number of stored nonzeros (same sparsity " *
+        "pattern): factored matrix has $(length(old._nzval)), new matrix has " *
+        "$(length(A._nzval))"))
+
+    family = _refactor_family(aa_fact._factorization.symbolicFactorization.type)
+    nfopts = Ref(SparseNumericFactorOptions(T))
+    factref = Ref(aa_fact._factorization)
+    GC.@preserve A begin
+        _sparse_refactor!(factref, A.matrix, nfopts, Val(family))
+    end
+    new_fact = factref[]
+    _libsparse_throw(new_fact.status, "refactor")
+    aa_fact._factorization = new_fact
+    # Keep the new matrix alive: its CSC buffers now back the numeric factors'
+    # input, and dropping the old wrapper avoids confusion about which values
+    # the factorization reflects.
+    aa_fact.matrixObj = A
+    return aa_fact
+end
+
+# ===========================================================================
+# Installation into the parent module + forwarding on load
+# ===========================================================================
+
+function __init__()
+    # BLAS/LAPACK forwarding. Mirror the macOS-version guard that the core
+    # __init__ used before forwarding was moved here.
+    ver = get_macos_version()
+    # dsptrf has a bug in the initial release of the $NEWLAPACK symbols in 13.3;
+    # require macOS 13.4 for ILP64, a correct LAPACK, and threading APIs.
+    if ver === nothing || ver < v"13.4"
+        @info "AppleAccelerate.jl needs macOS 13.4 or later for BLAS/LAPACK forwarding"
+        return
+    end
+    AppleAccelerate.load_accelerate(; clear = false, load_ilp64 = true)
+end
+
+end # @static if Sys.isapple()
+
+end # module

--- a/ext/AppleAccelerateLinearAlgebraSparseArraysExt.jl
+++ b/ext/AppleAccelerateLinearAlgebraSparseArraysExt.jl
@@ -1,0 +1,103 @@
+module AppleAccelerateLinearAlgebraSparseArraysExt
+
+@static if Sys.isapple()
+
+using AppleAccelerate
+using AppleAccelerate: vTypes, AASparseMatrix,
+                       SparseFactorization_t,
+                       SparseFactorizationCholesky, SparseFactorizationQR,
+                       SparseFactorizationLU, SparseFactorizationLDLT,
+                       factor!, solve, refactor!
+using LinearAlgebra
+using SparseArrays
+using SparseArrays: SparseMatrixCSC
+
+# This extension provides the idiomatic LinearAlgebra entry points
+# (`lu`/`cholesky`/`qr`/`ldlt`/`factorize`/`\`) and the `AAFactorization`
+# constructor that accept a standard Julia `SparseMatrixCSC`. They require BOTH
+# the `SparseMatrixCSC` type (SparseArrays) AND the `AAFactorization` machinery
+# (defined in the LinearAlgebra extension), hence the dual trigger.
+#
+# `AppleAccelerate.AAFactorization` is installed into the AppleAccelerate module
+# by the LinearAlgebra extension's `__init__`. Reference it through the parent
+# module so this extension does not depend on the other extension's module path.
+
+# AAFactorization construction from a CSC (the core lacks the type; the
+# SparseArrays ext lacks the LinearAlgebra-defined AAFactorization).
+function AppleAccelerate.AAFactorization(M::SparseMatrixCSC{T, Int64}) where T<:vTypes
+    return AppleAccelerate.AAFactorization(AASparseMatrix(M))
+end
+
+# Build (but don't yet compute) an AAFactorization from a CSC, then force a
+# specific factorization kind.
+function _aa_factorize(A::SparseMatrixCSC{T,Int64}, kind::SparseFactorization_t) where {T<:vTypes}
+    f = AppleAccelerate.AAFactorization(A)
+    factor!(f, kind)
+    return f
+end
+
+"""
+    factorize(A::SparseMatrixCSC) -> AAFactorization
+
+Return an `AAFactorization` of `A` using Apple's Sparse solvers, with the
+factorization computed lazily on first solve (Cholesky for symmetric/Hermitian,
+LU/QR otherwise — see [`AppleAccelerate.factor!`](@ref)).
+"""
+LinearAlgebra.factorize(A::SparseMatrixCSC{T,Int64}) where {T<:vTypes} =
+    AppleAccelerate.AAFactorization(A)
+
+"""
+    cholesky(A::SparseMatrixCSC) -> AAFactorization
+
+Cholesky factorization via Apple's Sparse solvers. `A` must be symmetric
+(real) or Hermitian (complex) and positive definite.
+"""
+LinearAlgebra.cholesky(A::SparseMatrixCSC{T,Int64}) where {T<:vTypes} =
+    _aa_factorize(A, SparseFactorizationCholesky)
+
+"""
+    ldlt(A::SparseMatrixCSC) -> AAFactorization
+
+LDLᵀ factorization via Apple's Sparse solvers, for symmetric/Hermitian
+(indefinite) matrices.
+"""
+LinearAlgebra.ldlt(A::SparseMatrixCSC{T,Int64}) where {T<:vTypes} =
+    _aa_factorize(A, SparseFactorizationLDLT)
+
+"""
+    qr(A::SparseMatrixCSC) -> AAFactorization
+
+QR factorization via Apple's Sparse solvers. Works for rectangular matrices and
+solves least-squares systems through [`\\`](@ref).
+"""
+LinearAlgebra.qr(A::SparseMatrixCSC{T,Int64}) where {T<:vTypes} =
+    _aa_factorize(A, SparseFactorizationQR)
+
+"""
+    lu(A::SparseMatrixCSC) -> AAFactorization
+
+LU factorization via Apple's Sparse solvers (requires macOS 15.5+ for the
+libSparse LU path).
+"""
+LinearAlgebra.lu(A::SparseMatrixCSC{T,Int64}) where {T<:vTypes} =
+    _aa_factorize(A, SparseFactorizationLU)
+
+"""
+    A \\ b
+
+Solve the sparse linear system `A x = b` (or least-squares for rectangular `A`)
+using Apple's Sparse solvers, for `A::SparseMatrixCSC` and a dense `b`. Builds an
+`AAFactorization` internally and discards it; for repeated solves with the same
+`A`, build the factorization once with [`factorize`](@ref)/[`cholesky`](@ref)/…
+and reuse it.
+"""
+Base.:\(A::SparseMatrixCSC{T,Int64}, b::StridedVecOrMat{T}) where {T<:vTypes} =
+    solve(AppleAccelerate.AAFactorization(A), b)
+
+# refactor! accepting a CSC (needs both AAFactorization and SparseMatrixCSC).
+AppleAccelerate.refactor!(aa_fact, A::SparseMatrixCSC{T, Int64}) where T<:vTypes =
+    refactor!(aa_fact, AASparseMatrix(A))
+
+end # @static if Sys.isapple()
+
+end # module

--- a/ext/AppleAccelerateSparseArraysExt.jl
+++ b/ext/AppleAccelerateSparseArraysExt.jl
@@ -1,0 +1,98 @@
+module AppleAccelerateSparseArraysExt
+
+@static if Sys.isapple()
+
+using AppleAccelerate
+using AppleAccelerate: AASparseMatrix, vTypes,
+                       att_type, ATT_ORDINARY, ATT_HERMITIAN, ATT_SYMMETRIC,
+                       ATT_LOWER_TRIANGLE, ATT_TRI_LOWER, ATT_TRI_UPPER,
+                       ATT_UNIT_TRIANGULAR, ATT_TRANSPOSE, ATT_CONJUGATE_TRANSPOSE,
+                       ATT_TRIANGLE_MASK,
+                       _is_symmetric_attr, _is_hermitian_attr
+using SparseArrays
+using SparseArrays: SparseMatrixCSC
+
+# SparseArrays depends on (and loads) LinearAlgebra, but LinearAlgebra is only a
+# *weak* dependency of AppleAccelerate, so this extension cannot `using
+# LinearAlgebra` directly. We reach the (always-loaded) LinearAlgebra module
+# through SparseArrays' own binding for the few predicates we need (ishermitian,
+# istril, istriu, diag). tril/triu are re-exported by SparseArrays itself.
+const LA = SparseArrays.LinearAlgebra
+
+# Apple's Sparse solvers index with Clong column pointers / Cint row indices and
+# only support 64-bit-indexed CSC on the Julia side (`SparseMatrixCSC{T,Int64}`).
+const _CSC = SparseMatrixCSC{<:vTypes, Int64}
+
+# ---------------------------------------------------------------------------
+# Construction: SparseMatrixCSC -> AASparseMatrix
+# ---------------------------------------------------------------------------
+
+function AppleAccelerate.AASparseMatrix(sparseM::SparseMatrixCSC{T, Int64},
+                        attributes::att_type = ATT_ORDINARY) where T<:vTypes
+    if attributes == ATT_ORDINARY
+        if LA.ishermitian(sparseM)
+            kind = T <: Complex ? ATT_HERMITIAN : ATT_SYMMETRIC
+            return AASparseMatrix(LA.tril(sparseM), kind | ATT_LOWER_TRIANGLE)
+        elseif LA.istril(sparseM) || LA.istriu(sparseM)
+            attributes = LA.istril(sparseM) ? ATT_TRI_LOWER : ATT_TRI_UPPER
+        end
+    end
+    if attributes in (ATT_TRI_LOWER, ATT_TRI_UPPER) &&
+                    all(LA.diag(sparseM) .== one(eltype(sparseM)))
+        attributes |= ATT_UNIT_TRIANGULAR
+    end
+    c = Clong.(sparseM.colptr .+ -1)
+    r = Cint.(sparseM.rowval .+ -1)
+    vals = copy(sparseM.nzval)
+    return AASparseMatrix(size(sparseM)..., c, r, vals, attributes)
+end
+
+# ---------------------------------------------------------------------------
+# Conversion: AASparseMatrix -> SparseMatrixCSC
+# ---------------------------------------------------------------------------
+
+"""
+    SparseMatrixCSC(A::AASparseMatrix)
+
+Materialize an Accelerate `AASparseMatrix` back into a standard Julia
+`SparseMatrixCSC`. The transpose/adjoint attribute bits are honored, so the
+result equals the logical matrix `A` represents (`size`, `getindex`).
+"""
+function SparseArrays.SparseMatrixCSC(A::AASparseMatrix{T}) where {T<:vTypes}
+    attrs = A.matrix.structure.attributes
+    transposed = (attrs & ATT_TRANSPOSE) != 0
+    conj_t     = (attrs & ATT_CONJUGATE_TRANSPOSE) != 0
+    # Rebuild the raw *stored* CSC from the underlying buffers. These describe
+    # the matrix in libSparse's own (untransposed, lower/upper-as-stored) layout.
+    rawrows = Int(A.matrix.structure.rowCount)
+    rawcols = Int(A.matrix.structure.columnCount)
+    raw = SparseMatrixCSC{T,Int64}(rawrows, rawcols,
+                                   Int64.(A._colptr) .+ 1,
+                                   Int64.(A._rowval) .+ 1,
+                                   copy(A._nzval))
+
+    sym  = _is_symmetric_attr(A)
+    herm = T <: Complex && _is_hermitian_attr(A)
+    if sym || herm
+        # Stored as one triangle (plus diagonal); reflect to the full matrix.
+        # For symmetric/Hermitian kind, istril/istriu return false (they only
+        # report the *triangular* kind), so read the triangle bit directly.
+        lower = (attrs & ATT_TRIANGLE_MASK) == ATT_LOWER_TRIANGLE
+        tri = lower ? LA.tril(raw) : LA.triu(raw)
+        offdiag = lower ? LA.tril(raw, -1) : LA.triu(raw, 1)
+        full = tri + (herm ? adjoint(offdiag) : transpose(offdiag))
+        return SparseMatrixCSC{T,Int64}(full)
+    end
+
+    # Ordinary / triangular matrices: apply the view bits to the raw CSC.
+    out = raw
+    if transposed
+        out = conj_t ? SparseMatrixCSC{T,Int64}(copy(adjoint(out))) :
+                       SparseMatrixCSC{T,Int64}(copy(transpose(out)))
+    end
+    return out
+end
+
+end # @static if Sys.isapple()
+
+end # module

--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -1,5 +1,5 @@
 module AppleAccelerate
-using Libdl, LinearAlgebra
+using Libdl
 
 const libacc = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
 const libacc_info_plist = "/System/Library/Frameworks/Accelerate.framework/Versions/Current/Resources/Info.plist"
@@ -13,24 +13,18 @@ const _macos_version = Ref{Union{Nothing,VersionNumber}}(nothing)
     BLAS_THREADING_SINGLE_THREADED
 end
 
-function forward_accelerate(interface::Symbol;
-                            new_lapack::Bool = interface == :ilp64,
-                            clear::Bool = false,
-                            verbose::Bool = false)
-    kwargs = Dict{Symbol,String}()
-    if new_lapack
-        if interface == :ilp64
-            kwargs[:suffix_hint] = "\x1a\$NEWLAPACK\$ILP64"
-        else
-            kwargs[:suffix_hint] = "\x1a\$NEWLAPACK"
-        end
-    else
-        if interface == :ilp64
-            throw(ArgumentError("ILP64 accelerate requires new_lapack"))
-        end
-    end
-    BLAS.lbt_forward(libacc; clear, verbose, kwargs...)
-end
+# BLAS/LAPACK forwarding to Accelerate is provided by the LinearAlgebra package
+# extension (`ext/AppleAccelerateLinearAlgebraExt.jl`), since it depends on
+# `LinearAlgebra.BLAS.lbt_forward`. These are declared here as generic-function
+# stubs so the names resolve from core (e.g. for `__init__`/docs), with methods
+# added by the extension once `LinearAlgebra` is loaded.
+"""
+    forward_accelerate(interface::Symbol; new_lapack, clear, verbose)
+
+Forward BLAS/LAPACK symbols to Accelerate via libblastrampoline.
+Defined by the LinearAlgebra package extension; requires `using LinearAlgebra`.
+"""
+function forward_accelerate end
 
 """
     load_accelerate(; clear = false, verbose = false, load_ilp64 = true)
@@ -39,26 +33,11 @@ Load Accelerate, replacing the current LBT forwarding tables if `clear` is `true
 is `false` by default to allow for OpenBLAS to act as a fallback for operations missing
 from Accelerate, such as `gemmt`. Attempts to load the ILP64 symbols if `load_ilp64` is
 `true`, and errors out if unable.
+
+Defined by the LinearAlgebra package extension; requires `using LinearAlgebra`.
+With only `using AppleAccelerate`, BLAS/LAPACK forwarding does NOT happen.
 """
-function load_accelerate(; clear::Bool = false,
-                           verbose::Bool = false,
-                           load_ilp64::Bool = true)
-    libacc_hdl = dlopen_e(libacc)
-    if libacc_hdl == C_NULL
-        return
-    end
-
-    # Check to see if we can load ILP64 symbols
-    if load_ilp64 && dlsym_e(libacc_hdl, "dgemm\$NEWLAPACK\$ILP64") == C_NULL
-        error("Unable to load ILP64 interface from '$(libacc)'; you are running macOS $(get_macos_version()), you need v13.4+")
-    end
-
-    # First, load :lp64 symbols, optionally clearing the current LBT forwarding tables
-    forward_accelerate(:lp64; new_lapack=true, clear, verbose)
-    if load_ilp64
-        forward_accelerate(:ilp64; new_lapack=true, verbose)
-    end
-end
+function load_accelerate end
 
 """
     _read_macos_version()
@@ -110,7 +89,7 @@ function get_macos_version()
 end
 
 """
-    set_num_threads(n::Integer) -> BlasInt
+    set_num_threads(n::Integer) -> Int
 
 Set the number of threads used by Accelerate BLAS. If `n == 1`, use single-threaded mode;
 if `n > 1`, use multi-threaded mode. Returns the resulting thread count (from
@@ -121,7 +100,7 @@ function set_num_threads(n::Integer)
     ver = get_macos_version()
     if ver === nothing || ver < v"15"
         @warn "The Accelerate threading API requires macOS 15 or later; ignoring" maxlog=1
-        return LinearAlgebra.BlasInt(1)
+        return Int(1)
     end
 
     retval::Cint = -1
@@ -135,24 +114,26 @@ function set_num_threads(n::Integer)
 end
 
 """
-    get_num_threads() -> BlasInt
+    get_num_threads() -> Int
 
 Return the number of threads used by Accelerate BLAS. Returns `1` for single-threaded mode,
 or the actual thread count for multi-threaded mode. On macOS < 15 where the threading API
 is unavailable, warns and returns `1`.
 """
-function get_num_threads()::LinearAlgebra.BlasInt
+function get_num_threads()::Int
     ver = get_macos_version()
     if ver === nothing || ver < v"15"
         @warn "The Accelerate threading API requires macOS 15 or later" maxlog=1
-        return LinearAlgebra.BlasInt(1)
+        return Int(1)
     end
 
     retval::Threading = ccall((:BLASGetThreading, libacc), Threading, ())
     if retval == BLAS_THREADING_SINGLE_THREADED
-        return LinearAlgebra.BlasInt(1)
+        return Int(1)
     elseif retval == BLAS_THREADING_MULTI_THREADED
-        return ccall((:APPLE_NTHREADS, libacc), LinearAlgebra.BlasInt, ())
+        # APPLE_NTHREADS returns a C `int` (BlasInt would also work, but core
+        # must not depend on LinearAlgebra); read it as Cint and widen to Int.
+        return Int(ccall((:APPLE_NTHREADS, libacc), Cint, ()))
     else
         error("AppleAccelerate: BLASGetThreading returned unexpected value: $(retval)")
     end
@@ -163,12 +144,16 @@ function __init__()
     _macos_version[] = _read_macos_version()
     ver = _macos_version[]
     # dsptrf has a bug in the initial release of the $NEWLAPACK symbols in 13.3.
-    # Thus use macOS 13.4 for ILP64, a correct LAPACK, and threading APIs
+    # Thus use macOS 13.4 for ILP64, a correct LAPACK, and threading APIs.
+    #
+    # NOTE: BLAS/LAPACK forwarding is NO LONGER performed here. `using
+    # AppleAccelerate` alone does not touch LBT. Forwarding happens in the
+    # LinearAlgebra package extension's `__init__` (triggered by
+    # `using LinearAlgebra`), which re-applies the same macOS 13.4+ guard.
     if ver === nothing || ver < v"13.4"
-        @info "AppleAccelerate.jl needs macOS 13.4 or later for BLAS/LAPACK forwarding"
-        return
+        @info "AppleAccelerate.jl needs macOS 13.4 or later for BLAS/LAPACK forwarding " *
+              "(load LinearAlgebra to enable it)"
     end
-    load_accelerate(; clear = false, load_ilp64=true)
     # libSparse lives at a hard-coded path (LIBSPARSE in sparse.jl). Probe it once
     # here so a future macOS layout change surfaces a clear diagnostic instead of
     # an opaque dlopen error at the first sparse ccall.

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -1032,6 +1032,83 @@ function AAFactorization(A::AASparseMatrix{T}) where T<:vTypes
 end
 
 # ============================================================
+# Low-level numeric refactorization kernels
+# ============================================================
+# These call the plain-C `_SparseRefactor*` symbols directly and depend only on
+# the raw structs/enums + `LIBSPARSE` (no LinearAlgebra), so they live in core.
+# The user-facing `refactor!` that drives them is added by the LinearAlgebra
+# extension. (They were previously referenced by the extension but not defined
+# anywhere, which precompiled on Julia 1.11+ — where `using M: <undefined>` is
+# lazy — but failed on the 1.10 floor, where the import is eager.)
+
+const _REFACTOR_SYM = Dict(
+    # (T, kind) => (symbol)
+    (Cfloat,     :Symmetric) => :_SparseRefactorSymmetric_Float,
+    (Cdouble,    :Symmetric) => :_SparseRefactorSymmetric_Double,
+    (ComplexF32, :Symmetric) => :_SparseRefactorSymmetric_Complex_Float,
+    (ComplexF64, :Symmetric) => :_SparseRefactorSymmetric_Complex_Double,
+    (Cfloat,     :QR)        => :_SparseRefactorQR_Float,
+    (Cdouble,    :QR)        => :_SparseRefactorQR_Double,
+    (ComplexF32, :QR)        => :_SparseRefactorQR_Complex_Float,
+    (ComplexF64, :QR)        => :_SparseRefactorQR_Complex_Double,
+    (Cfloat,     :LU)        => :_SparseRefactorLU_Float,
+    (Cdouble,    :LU)        => :_SparseRefactorLU_Double,
+    (ComplexF32, :LU)        => :_SparseRefactorLU_Complex_Float,
+    (ComplexF64, :LU)        => :_SparseRefactorLU_Complex_Double,
+)
+
+# Map a SparseFactorization_t (read from the symbolic factorization) to the
+# refactor family. Mirrors the switch in SparseRefactor (SolveImplementationTyped.h).
+function _refactor_family(t::SparseFactorization_t)
+    if t in (SparseFactorizationQR, SparseFactorizationCholeskyAtA)
+        return :QR
+    elseif t in (SparseFactorizationLU, SparseFactorizationLUUnpivoted,
+                 SparseFactorizationLUSPP, SparseFactorizationLUTPP)
+        return :LU
+    else
+        # Cholesky and the LDLT family all go through the "symmetric" refactor.
+        return :Symmetric
+    end
+end
+
+# Per-type workspace size of the symbolic factorization.
+_refactor_workspace_size(s::SparseOpaqueSymbolicFactorization, ::Type{<:Union{Cfloat,ComplexF32}}) =
+    Int(s.workspaceSize_Float)
+_refactor_workspace_size(s::SparseOpaqueSymbolicFactorization, ::Type{<:Union{Cdouble,ComplexF64}}) =
+    Int(s.workspaceSize_Double)
+
+# Low-level refactor: recompute the numeric factorization of `fact` in place
+# using the values of `matrix`. `matrix` must share the sparsity pattern of the
+# matrix `fact` was originally built from. Returns the (mutated) factorization.
+for ((T, kind), sym) in _REFACTOR_SYM
+    @eval function _sparse_refactor!(fact::Base.RefValue{SparseOpaqueFactorization{$T}},
+                                     matrix::SparseMatrix{$T},
+                                     nfopts::Base.RefValue{SparseNumericFactorOptions},
+                                     ::Val{$(QuoteNode(kind))})
+        symb = fact[].symbolicFactorization
+        wsize = _refactor_workspace_size(symb, $T)
+        workspace = Libc.malloc(wsize)
+        workspace != C_NULL || throw(OutOfMemoryError())
+        try
+            # The plain-C `_SparseRefactor*` symbols take the matrix BY POINTER
+            # (`SparseMatrix_Double *`), unlike the C++ `SparseFactor` entry point
+            # which takes it by value. Passing the struct by value misaligns the
+            # x86_64 SysV argument registers (it lands on the stack), which crashed
+            # libSparse with SIGILL on Intel macOS while happening to work on arm64
+            # (large structs are passed indirectly there). Pass via `Ref` so ccall
+            # hands over a GC-rooted pointer matching the generated ABI.
+            @ccall LIBSPARSE.$sym(matrix::Ref{SparseMatrix{$T}},
+                                  fact::Ptr{SparseOpaqueFactorization{$T}},
+                                  nfopts::Ptr{SparseNumericFactorOptions},
+                                  workspace::Ptr{Cvoid})::Cvoid
+        finally
+            Libc.free(workspace)
+        end
+        return fact[]
+    end
+end
+
+# ============================================================
 # Stubs for the factorize/solve subsystem (implemented in extensions)
 # ============================================================
 #

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -1,6 +1,17 @@
 ## sparse.jl ##
+#
+# Core sparse support. This file must NOT reference `LinearAlgebra` or
+# `SparseArrays` — those are weak dependencies. It provides:
+#   * the raw libSparse ABI (enums, structs, ccall wrappers via @generateDemangled)
+#   * `AASparseMatrix` (subtypes Base.AbstractMatrix) + the raw-array constructor
+#   * sparse × dense multiply / `muladd!`
+#   * the low-level numeric refactor kernels
+#
+# The `AAFactorization`/`factor!`/`solve`/`refactor!`/`factorize` subsystem and
+# the `SparseMatrixCSC` <-> `AASparseMatrix` conversions live in package
+# extensions (see ext/). Generic-function stubs for the ext-defined operations
+# are declared at the bottom of this file so the names resolve from core.
 
-using SparseArrays
 using Libdl
 
 # To find most recent header:
@@ -847,25 +858,10 @@ function AASparseMatrix(n::Int, m::Int,
     return AASparseMatrix(m, col, row, data)
 end
 
-function AASparseMatrix(sparseM::SparseMatrixCSC{T, Int64},
-                        attributes::att_type = ATT_ORDINARY) where T<:vTypes
-    if attributes == ATT_ORDINARY
-        if ishermitian(sparseM)
-            kind = T <: Complex ? ATT_HERMITIAN : ATT_SYMMETRIC
-            return AASparseMatrix(tril(sparseM), kind | ATT_LOWER_TRIANGLE)
-        elseif istril(sparseM) || istriu(sparseM)
-            attributes = istril(sparseM) ? ATT_TRI_LOWER : ATT_TRI_UPPER
-        end
-    end
-    if attributes in (ATT_TRI_LOWER, ATT_TRI_UPPER) &&
-                    all(diag(sparseM) .== one(eltype(sparseM)))
-        attributes |= ATT_UNIT_TRIANGULAR
-    end
-    c = Clong.(sparseM.colptr .+ -1)
-    r = Cint.(sparseM.rowval .+ -1)
-    vals = copy(sparseM.nzval)
-    return AASparseMatrix(size(sparseM)..., c, r, vals, attributes)
-end
+# NOTE: the `AASparseMatrix(::SparseMatrixCSC{T,Int64})` constructor (and the
+# `SparseMatrixCSC(::AASparseMatrix)` round-trip) live in the SparseArrays
+# package extension (ext/AppleAccelerateSparseArraysExt.jl), since they require
+# the `SparseMatrixCSC` type. `using SparseArrays` enables them.
 
 # Apple stores the underlying CSC dimensions and uses the transpose attribute
 # bit to "implicitly transpose" the matrix on subsequent ops. Julia callers
@@ -878,17 +874,22 @@ function Base.size(M::AASparseMatrix)
         (ncol, nrow) : (nrow, ncol)
 end
 
-LinearAlgebra.issymmetric(M::AASparseMatrix{T}) where T = (M.matrix.structure.attributes &
-                                                attr_mask(T)) == ATT_SYMMETRIC
-LinearAlgebra.ishermitian(M::AASparseMatrix{<:Complex}) = (M.matrix.structure.attributes &
-                                                ATT_KIND_MASK_COMPLEX) == ATT_HERMITIAN
-LinearAlgebra.ishermitian(M::AASparseMatrix{<:Real}) = issymmetric(M)
-istri(M::AASparseMatrix{T}) where T = (M.matrix.structure.attributes
-                                    & attr_mask(T)) == ATT_TRIANGULAR
-LinearAlgebra.istriu(M::AASparseMatrix) = istri(M) && (M.matrix.structure.attributes &
-                                        ATT_TRIANGLE_MASK == ATT_UPPER_TRIANGLE)
-LinearAlgebra.istril(M::AASparseMatrix) = istri(M) && (M.matrix.structure.attributes &
-                                        ATT_TRIANGLE_MASK == ATT_LOWER_TRIANGLE)
+# Package-private predicates reading the attribute bits. Core must not call
+# `LinearAlgebra.issymmetric`/`ishermitian`/`istriu`/`istril`, so these provide
+# the same information without a LinearAlgebra dependency. The LinearAlgebra
+# package extension defines `LinearAlgebra.issymmetric`/`ishermitian`/`istriu`/
+# `istril` on `AASparseMatrix` by delegating to these helpers.
+_is_symmetric_attr(M::AASparseMatrix{T}) where T =
+    (M.matrix.structure.attributes & attr_mask(T)) == ATT_SYMMETRIC
+_is_hermitian_attr(M::AASparseMatrix{<:Complex}) =
+    (M.matrix.structure.attributes & ATT_KIND_MASK_COMPLEX) == ATT_HERMITIAN
+_is_hermitian_attr(M::AASparseMatrix{<:Real}) = _is_symmetric_attr(M)
+istri(M::AASparseMatrix{T}) where T =
+    (M.matrix.structure.attributes & attr_mask(T)) == ATT_TRIANGULAR
+_is_triu_attr(M::AASparseMatrix) = istri(M) &&
+    (M.matrix.structure.attributes & ATT_TRIANGLE_MASK == ATT_UPPER_TRIANGLE)
+_is_tril_attr(M::AASparseMatrix) = istri(M) &&
+    (M.matrix.structure.attributes & ATT_TRIANGLE_MASK == ATT_LOWER_TRIANGLE)
 
 # Both bits encode adjoint; ct alone is the "no meaning" state that
 # libSparse treats as identity (reachable via adjoint(adjoint(M))).
@@ -979,20 +980,40 @@ function muladd!(alpha::T, A::AASparseMatrix{T},
     SparseMultiplyAdd(alpha, A.matrix, x, y)
 end
 
-# ============================================================
-# AAFactorization
-# ============================================================
 
+# ============================================================
+# AAFactorization (type lives in core; operations live in the LinearAlgebra ext)
+# ============================================================
+#
+# The factorize/solve subsystem extends `LinearAlgebra` (`LinearAlgebra.ldiv!`,
+# `LinearAlgebra.factorize`, `LinearAlgebra.SingularException`, the `\` fallback,
+# …), so those *operations* live in the LinearAlgebra package extension
+# (ext/AppleAccelerateLinearAlgebraExt.jl), with `factor!`/`solve`/`solve!`/
+# `refactor!` declared as core stubs below.
+#
+# The `AAFactorization` *type* itself, however, must be a real binding in this
+# (core) module: package extensions cannot define methods/constructors on a
+# binding that does not yet exist at their precompile time, and the dual
+# LinearAlgebra+SparseArrays extension needs to add a `SparseMatrixCSC`
+# constructor for it. We therefore define the struct here. It does NOT subtype
+# `LinearAlgebra.Factorization` (core has no LinearAlgebra dependency); the
+# LinearAlgebra extension supplies the `Factorization`-style API instead,
+# including a `Base.:\(::AAFactorization, b)` method that would otherwise come
+# from the `Factorization` supertype.
 @doc """Factorization object.
 
-Create via `f = AAFactorization(A::SparseMatrixCSC{T, Int64})`. Calls to `solve`,
+Create via `f = AAFactorization(A::SparseMatrixCSC{T, Int64})` (requires
+`using SparseArrays`) or `AAFactorization(A::AASparseMatrix)`. Calls to `solve`,
 `ldiv`, and their in-place versions require explicitly passing in the
 factorization object as the first argument. On construction, the struct stores a
-placeholder yet-to-be-factored object: the factorization is computed upon the first call
-to `solve`, or by explicitly calling `factor!`. If the matrix is symmetric, it defaults to
-a Cholesky factorization; otherwise, it defaults to QR.
+placeholder yet-to-be-factored object: the factorization is computed upon the
+first call to `solve`, or by explicitly calling `factor!`. If the matrix is
+symmetric, it defaults to a Cholesky factorization; otherwise, it defaults to QR.
+
+`factor!`/`solve`/`solve!`/`refactor!`/`ldiv!`/`\\` and `factorize` require
+`using LinearAlgebra` (they are provided by a package extension).
 """
-mutable struct AAFactorization{T<:vTypes} <: LinearAlgebra.Factorization{T}
+mutable struct AAFactorization{T<:vTypes}
     matrixObj::AASparseMatrix{T}
     _factorization::SparseOpaqueFactorization{T}
 end
@@ -1010,133 +1031,43 @@ function AAFactorization(A::AASparseMatrix{T}) where T<:vTypes
     return finalizer(cleanup, obj)
 end
 
-LinearAlgebra.factorize(A::AASparseMatrix{T}) where T<:vTypes = AAFactorization(A)
+# ============================================================
+# Stubs for the factorize/solve subsystem (implemented in extensions)
+# ============================================================
+#
+# Declared as generic-function stubs so the names resolve from `AppleAccelerate`
+# (and `import AppleAccelerate: factor!, solve, …` works); methods are added by
+# the LinearAlgebra extension once `LinearAlgebra` is loaded.
 
-# julia's LinearAlgebra module doesn't provide similar constructors.
-AAFactorization(M::SparseMatrixCSC{T, Int64}) where T<:vTypes =
-                                        AAFactorization(AASparseMatrix(M))
-
-# easiest way to make this follow the defaults and naming conventions of LinearAlgebra?
 """
     factor!(f::AAFactorization, [type::SparseFactorization_t])
 
-Explicitly compute the factorization. If `type` is not specified, the default
-is chosen from the matrix's kind attribute:
-
-  - Hermitian (real symmetric or complex Hermitian) → Cholesky
-  - square, non-Hermitian → LU (macOS 15.5+; falls back to QR on older systems)
-  - rectangular → QR
-
-Called automatically by [`solve`](@ref) if the factorization has not yet been
-computed.
-
-!!! note "Complex symmetric (not Hermitian)"
-    When the user leaves the factorization type unspecified and passes
-    a complex symmetric (but not Hermitian) matrix, we default to LU factorization.
-    
-    On older versions of MacOS, Apple's `SparseFactorizationLDLT` errors on complex
-    symmetric (non-Hermitian) matrices, reporting "Cannot
-    perform Hermitian matrix factorization of non-Hermitian matrix."
-    On newer versions, it accepts the call and performs a true `LDLᵀ` (not `LDLᴴ`).
-    This behavior isn't documented by Apple; the exact version threshold is
-    unknown.
+Explicitly compute the factorization. Defined by the LinearAlgebra package
+extension; requires `using LinearAlgebra`.
 """
-function factor!(aa_fact::AAFactorization{T},
-            kind::SparseFactorization_t = SparseFactorizationTBD) where T<:vTypes
-    if aa_fact._factorization.status == SparseYetToBeFactored
-        if kind == SparseFactorizationTBD
-            # Cholesky for Hermitian (incl. real symmetric); LU for square
-            # non-Hermitian (macOS 15.5+); QR otherwise.
-            nrow, ncol = size(aa_fact.matrixObj)
-            lu_ok = something(_macos_version[], v"0.0.0") >= v"15.5"
-            kind = ishermitian(aa_fact.matrixObj) ? SparseFactorizationCholesky :
-                   (nrow == ncol && lu_ok)        ? SparseFactorizationLU :
-                                                    SparseFactorizationQR
-        end
-        fact = SparseFactor(kind, aa_fact.matrixObj.matrix)
-        if fact.status == SparseStatusOk
-            aa_fact._factorization = fact
-        else
-            # The factorization failed (e.g. singular matrix). Free whatever
-            # SparseFactor allocated for the failed attempt, but leave the
-            # original yet-to-be-factored placeholder in place so (a) the
-            # finalizer never calls SparseCleanup on a non-Ok object and
-            # (b) a subsequent factor! retries instead of silently reusing a
-            # broken factorization.
-            SparseCleanup(fact)
-            _libsparse_throw(fact.status, "factor")
-        end
-    end
-end
-
-# Translate a libSparse status code into a typed Julia exception. SparseStatusOk
-# is a no-op so callers can write `_libsparse_throw(result.status, ...)` after
-# every libSparse call without branching.
-function _libsparse_throw(status::SparseStatus_t, op::AbstractString)
-    status == SparseStatusOk && return
-    status == SparseMatrixIsSingular &&
-        throw(LinearAlgebra.SingularException(0))
-    status == SparseParameterError &&
-        throw(ArgumentError("libSparse $(op) failed: parameter error " *
-            "(possibly: matrix lacks the properties required by this factorization, " *
-            "or factorization is unavailable on this macOS version)"))
-    status == SparseStatusFailed &&
-        error("libSparse $(op) failed (check that the matrix has the correct " *
-              "properties for this factorization)")
-    status == SparseInternalError &&
-        error("libSparse $(op) failed: internal error")
-    error("libSparse $(op) failed: status=$(status)")
-end
+function factor! end
 
 """
     solve(f::AAFactorization, b::StridedVecOrMat)
 
-Solve the linear system `Ax = b` using Apple's Sparse Solvers, returning the solution `x`.
-The factorization is computed lazily on the first call if not already factored.
-Equivalent to `f \\ b`.
+Solve `Ax = b` with Apple's Sparse Solvers, returning `x`. Defined by the
+LinearAlgebra package extension; requires `using LinearAlgebra`.
 """
-function solve(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T}) where T<:vTypes
-    size(aa_fact.matrixObj)[1] != size(b, 1) && throw(DimensionMismatch(
-        "Matrix and right-hand side size mismatch: got "
-        * "$(size(aa_fact.matrixObj)[1]) and $(size(b, 1))"))
-    factor!(aa_fact)
-    x = Array{T}(undef, size(aa_fact.matrixObj)[2], size(b)[2:end]...)
-    SparseSolve(aa_fact._factorization, b, x)
-    return x
-end
+function solve end
 
 """
     solve!(f::AAFactorization, xb::StridedVecOrMat)
 
-Solve the linear system `Ax = b` in-place, overwriting `xb` with the solution.
-On input `xb` contains the right-hand side `b`; on output it contains the solution `x`.
-Equivalent to `ldiv!(f, xb)`.
+In-place solve overwriting `xb` with the solution. Defined by the LinearAlgebra
+package extension; requires `using LinearAlgebra`.
 """
-function solve!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vTypes
-    ((xb isa StridedMatrix) &&
-        (size(aa_fact.matrixObj)[1] != size(aa_fact.matrixObj)[2])) &&
-        throw(ArgumentError("Can't in-place " *
-                "solve: x and b are different sizes and Julia cannot resize a matrix."
-            )
-        )
-    factor!(aa_fact)
-    SparseSolve(aa_fact._factorization, xb)
-    return xb # written in imitation of KLU.jl, which also returns
-end
+function solve! end
 
-LinearAlgebra.ldiv!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vTypes =
-        solve!(aa_fact, xb)
+"""
+    refactor!(f::AAFactorization, A)
 
-function LinearAlgebra.ldiv!(x::StridedVecOrMat{T},
-                            aa_fact::AAFactorization{T},
-                            b::StridedVecOrMat{T}) where T<:vTypes
-    size(aa_fact.matrixObj)[1] != size(b, 1) && throw(DimensionMismatch(
-        "Matrix and right-hand side size mismatch: got "
-        * "$(size(aa_fact.matrixObj)[1]) and $(size(b, 1))"))
-    size(aa_fact.matrixObj)[2] != size(x, 1) && throw(DimensionMismatch(
-        "Matrix and output size mismatch: got "
-        * "$(size(aa_fact.matrixObj)[2]) and $(size(x, 1))"))
-    factor!(aa_fact)
-    SparseSolve(aa_fact._factorization, b, x)
-    return x
-end
+Recompute the numeric factorization stored in `f` from the values of `A`,
+reusing the existing symbolic factorization. Defined by the LinearAlgebra
+package extension; requires `using LinearAlgebra`.
+"""
+function refactor! end

--- a/test/extension_loading_tests.jl
+++ b/test/extension_loading_tests.jl
@@ -1,0 +1,150 @@
+using Test
+
+# These tests verify the package *contract* around weak dependencies and package
+# extensions. Each scenario runs in a FRESH julia subprocess (so the parent test
+# process, which loads LinearAlgebra/SparseArrays for the rest of the suite,
+# cannot contaminate the observation). We reuse the parent's active project and
+# load path so the subprocesses see the same (already-instantiated) environment.
+
+const _PROJECT = Base.active_project()
+const _LOAD_PATH = join(Base.LOAD_PATH, Sys.iswindows() ? ';' : ':')
+
+# Run a snippet in a fresh julia process; return (exitcode, combined output).
+function _run_julia(code::AbstractString)
+    cmd = `$(Base.julia_cmd()) --project=$(_PROJECT) --startup-file=no --color=no -e $code`
+    cmd = addenv(cmd, "JULIA_LOAD_PATH" => _LOAD_PATH)
+    out = IOBuffer()
+    p = run(pipeline(ignorestatus(cmd); stdout = out, stderr = out))
+    return (p.exitcode, String(take!(out)))
+end
+
+# Is LinearAlgebra baked into the running sysimage? The default Julia 1.12
+# sysimage (`sys.dylib`) preloads LinearAlgebra (and SparseArrays), so they
+# already appear in `Base.loaded_modules` of every fresh process — which means
+# the LinearAlgebra/SparseArrays-triggered extensions activate automatically.
+# That is *correct* extension behavior (the trigger module is genuinely loaded);
+# it simply means a sysimage-preloaded stdlib cannot be observed as "absent".
+# We detect this so the bare-absence assertions only run on a sysimage that does
+# NOT preload these stdlibs (e.g. a slim/base image).
+const _LA_IN_SYSIMAGE = let
+    ec, out = _run_julia("""
+        println(any(occursin("LinearAlgebra", string(m)) for m in values(Base.loaded_modules)))
+    """)
+    ec == 0 && occursin("true", out)
+end
+
+@testset "Extension loading / package contract" begin
+    @testset "bare `using AppleAccelerate` (no weakdeps, no forwarding)" begin
+        if _LA_IN_SYSIMAGE
+            @info "LinearAlgebra is preloaded in this sysimage; the extension " *
+                  "activates automatically. Skipping bare-absence assertions " *
+                  "(cannot observe a sysimage stdlib as absent)."
+            # Still verify the threading API has no LinearAlgebra dependency.
+            code = """
+            using AppleAccelerate
+            @assert AppleAccelerate.get_num_threads() isa Int
+            # Core must not contain the forwarding *bodies*; the names are stubs
+            # until the extension adds methods.
+            @assert isdefined(AppleAccelerate, :load_accelerate)
+            @assert isdefined(AppleAccelerate, :forward_accelerate)
+            println("BARE_OK")
+            """
+            ec, out = _run_julia(code)
+            @test ec == 0
+            @test occursin("BARE_OK", out)
+        else
+            code = """
+            using AppleAccelerate
+            loaded = Set(string(m) for m in values(Base.loaded_modules))
+            @assert !("LinearAlgebra" in loaded) "LinearAlgebra unexpectedly loaded"
+            @assert !("SparseArrays" in loaded) "SparseArrays unexpectedly loaded"
+            @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraExt) === nothing
+            @assert Base.get_extension(AppleAccelerate, :AppleAccelerateSparseArraysExt) === nothing
+            @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraSparseArraysExt) === nothing
+            @assert AppleAccelerate.get_num_threads() isa Int
+            # Bare load must NOT forward BLAS to Accelerate.
+            using LinearAlgebra
+            cfg = sprint(show, LinearAlgebra.BLAS.get_config())
+            # (We just loaded LinearAlgebra; forwarding may now be on. The point
+            # of this branch is that it was off *before* this line.)
+            println("BARE_OK")
+            """
+            ec, out = _run_julia(code)
+            @test ec == 0
+            @test occursin("BARE_OK", out)
+        end
+    end
+
+    @testset "BLAS forwarding is tied to the LinearAlgebra extension" begin
+        # Once LinearAlgebra is present, the extension forwards BLAS to Accelerate.
+        code = """
+        using AppleAccelerate
+        import LinearAlgebra
+        if AppleAccelerate.get_macos_version() === nothing || AppleAccelerate.get_macos_version() < v"13.4"
+            println("FORWARD_SKIPPED")
+        else
+            cfg = sprint(show, LinearAlgebra.BLAS.get_config())
+            @assert occursin("Accelerate", cfg) || occursin("libacc", cfg) "BLAS not forwarded to Accelerate: \$cfg"
+            @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraExt) !== nothing
+            println("FORWARD_OK")
+        end
+        """
+        ec, out = _run_julia(code)
+        @test ec == 0
+        @test occursin("FORWARD_OK", out) || occursin("FORWARD_SKIPPED", out)
+    end
+
+    @testset "LinearAlgebra extension activates with LinearAlgebra" begin
+        # `_NEG` guards the negative assertions: they only hold when the *other*
+        # trigger stdlib is not preloaded into the sysimage.
+        code = """
+        using AppleAccelerate
+        using LinearAlgebra
+        @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraExt) !== nothing
+        if !$(_LA_IN_SYSIMAGE)
+            @assert Base.get_extension(AppleAccelerate, :AppleAccelerateSparseArraysExt) === nothing
+            @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraSparseArraysExt) === nothing
+        end
+        println("LA_EXT_OK")
+        """
+        ec, out = _run_julia(code)
+        @test ec == 0
+        @test occursin("LA_EXT_OK", out)
+    end
+
+    @testset "SparseArrays extension activates with SparseArrays only" begin
+        code = """
+        using AppleAccelerate
+        using SparseArrays
+        @assert Base.get_extension(AppleAccelerate, :AppleAccelerateSparseArraysExt) !== nothing
+        # Construction from a SparseMatrixCSC works with just SparseArrays.
+        A = sparse([1.0 0.0; 0.0 2.0])
+        aa = AppleAccelerate.AASparseMatrix(A)
+        @assert SparseMatrixCSC(aa) == A
+        println("SA_EXT_OK")
+        """
+        ec, out = _run_julia(code)
+        @test ec == 0
+        @test occursin("SA_EXT_OK", out)
+    end
+
+    @testset "dual extension activates only with both" begin
+        code = """
+        using AppleAccelerate
+        using LinearAlgebra
+        using SparseArrays
+        @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraExt) !== nothing
+        @assert Base.get_extension(AppleAccelerate, :AppleAccelerateSparseArraysExt) !== nothing
+        @assert Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraSparseArraysExt) !== nothing
+        # End-to-end: factorize/solve a CSC via the dual extension.
+        A = sparse([2.0 0.0; 0.0 3.0])
+        b = [2.0, 9.0]
+        x = A \\ b
+        @assert isapprox(x, [1.0, 3.0]; atol = 1e-8) "dual-ext solve wrong: \$x"
+        println("DUAL_EXT_OK")
+        """
+        ec, out = _run_julia(code)
+        @test ec == 0
+        @test occursin("DUAL_EXT_OK", out)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,24 @@
-using LinearAlgebra
 using AppleAccelerate
-using AbstractFFTs
-using DSP, FFTW, Random, Statistics, Test
-using Aqua
+using Test
 
 if !Sys.isapple()
     @info("AppleAccelerate.jl will be tested only on macOS. Exiting.")
     exit(0)
 end
+
+# Extension-loading / package-contract tests run FIRST, in fresh subprocesses,
+# so they can observe the bare `using AppleAccelerate` state (no LinearAlgebra /
+# SparseArrays, no BLAS forwarding) before this process loads the weakdeps below.
+include("extension_loading_tests.jl")
+
+# Load the weakdep triggers so the package extensions (LinearAlgebra,
+# SparseArrays, and the dual LinearAlgebra+SparseArrays extension) activate for
+# the remaining test files, which use sparse/factorization/forwarding freely.
+using LinearAlgebra
+using SparseArrays
+using AbstractFFTs
+using DSP, FFTW, Random, Statistics
+using Aqua
 
 @testset "Aqua" begin
     Aqua.test_all(AppleAccelerate)

--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -148,17 +148,21 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, solve
         @testset "_libsparse_throw status mapping" begin
             # Code coverage reasons: no easy was to trigger the SparseInternalError.
             AA = AppleAccelerate
-            @test AA._libsparse_throw(AA.SparseStatusOk, "x") === nothing
-            @test_throws SingularException AA._libsparse_throw(
+            # `_libsparse_throw` lives in the LinearAlgebra extension (it throws
+            # LinearAlgebra.SingularException), so reach it via the extension.
+            LAExt = Base.get_extension(AppleAccelerate, :AppleAccelerateLinearAlgebraExt)
+            @test LAExt !== nothing
+            @test LAExt._libsparse_throw(AA.SparseStatusOk, "x") === nothing
+            @test_throws SingularException LAExt._libsparse_throw(
                 AA.SparseMatrixIsSingular, "factor")
-            @test_throws ArgumentError AA._libsparse_throw(
+            @test_throws ArgumentError LAExt._libsparse_throw(
                 AA.SparseParameterError, "factor")
-            @test_throws ErrorException AA._libsparse_throw(
+            @test_throws ErrorException LAExt._libsparse_throw(
                 AA.SparseStatusFailed, "factor")
-            @test_throws ErrorException AA._libsparse_throw(
+            @test_throws ErrorException LAExt._libsparse_throw(
                 AA.SparseInternalError, "factor")
             # Unknown / unmapped status falls through to the generic branch.
-            @test_throws ErrorException AA._libsparse_throw(
+            @test_throws ErrorException LAExt._libsparse_throw(
                 AA.SparseYetToBeFactored, "factor")
         end
 


### PR DESCRIPTION
## The new package contract

This PR re-architects AppleAccelerate so that **`LinearAlgebra` and `SparseArrays` are weak dependencies**, with all BLAS/LAPACK forwarding and LinearAlgebra/SparseArrays integration moved into package extensions.

- `using AppleAccelerate` alone → raw bindings + `array.jl`/`dsp.jl`/`complexarray.jl` + `AASparseMatrix` construction-from-raw + sparse×dense multiply + the threading API. **No BLAS/LAPACK forwarding.**
- `using AppleAccelerate, LinearAlgebra` → the LinearAlgebra extension loads and its `__init__` performs forwarding (`load_accelerate`); also enables the factorize/solve subsystem.
- `using AppleAccelerate, SparseArrays` → the SparseArrays extension enables building `AASparseMatrix` from `SparseMatrixCSC` and back.
- `using AppleAccelerate, LinearAlgebra, SparseArrays` → the dual extension enables `lu`/`cholesky`/`qr`/`ldlt`/`\`/`factorize` on `SparseMatrixCSC`.

**User-visible semantics change:** forwarding now requires `using LinearAlgebra`; sparse construction from `SparseMatrixCSC` requires `using SparseArrays`. Previously forwarding happened on bare `using AppleAccelerate`.

## Three-extension layout — what moved where

**Core (`src/`, no LinearAlgebra/SparseArrays references):**
- `AppleAccelerate.jl`: removed `using LinearAlgebra`; `__init__` now only caches the macOS version and probes `LIBSPARSE` (forwarding removed). Threading API (`set_num_threads`/`get_num_threads`) uses `Int`/`Cint` instead of `LinearAlgebra.BlasInt`. `forward_accelerate`/`load_accelerate` are core stubs.
- `sparse.jl`: keeps the raw ABI (enums/structs/`@generateDemangled` ccalls, `SparseFactor`/`SparseSolve`/`SparseCleanup`), `AASparseMatrix` + raw constructor, `*`/`muladd!`, the low-level numeric refactor kernels, and package-private attribute-bit predicates (`_is_symmetric_attr`/`_is_hermitian_attr`/`_is_triu_attr`/`_is_tril_attr`). `factor!`/`solve`/`solve!`/`refactor!` are stubs.

**`ext/AppleAccelerateLinearAlgebraExt.jl`** (trigger `LinearAlgebra`): `forward_accelerate`/`load_accelerate` bodies + `__init__` forwarding (preserving LP64-then-ILP64, `new_lapack=true`, the `\x1a$NEWLAPACK[$ILP64]` suffix_hint, the macOS 13.4+ guard, `clear=false`); the full factorize/solve subsystem (`factor!`/`solve`/`solve!`/`refactor!`/`ldiv!`/`factorize(::AASparseMatrix)`/`Base.:\`); `_libsparse_throw`; and `LinearAlgebra.issymmetric`/`ishermitian`/`istriu`/`istril` on `AASparseMatrix`.

**`ext/AppleAccelerateSparseArraysExt.jl`** (trigger `SparseArrays`): `AASparseMatrix(::SparseMatrixCSC{T,Int64})` and `SparseMatrixCSC(::AASparseMatrix)`.

**`ext/AppleAccelerateLinearAlgebraSparseArraysExt.jl`** (trigger `["LinearAlgebra","SparseArrays"]`): `lu`/`cholesky`/`qr`/`ldlt`/`factorize`/`\` on `SparseMatrixCSC`, `AAFactorization(::SparseMatrixCSC)`, and `refactor!(::SparseMatrixCSC)`.

## `AAFactorization <: Factorization` placement

The spec preferred defining `AAFactorization <: LinearAlgebra.Factorization` in the LinearAlgebra ext. That is **infeasible** here: the dual extension must add a `SparseMatrixCSC` constructor to `AAFactorization`, and a package extension cannot define methods/constructors on a binding that doesn't exist at *its* precompile time (an ext-defined type is not a binding of the parent module at the dual ext's precompile). Resolution: the `AAFactorization` **struct lives in core** as a plain `mutable struct` (no `Factorization` supertype — core has no LinearAlgebra dependency). The LinearAlgebra ext supplies the full `Factorization`-style API, including an explicit `Base.:\(::AAFactorization, b)` that the supertype would otherwise have provided. `import AppleAccelerate: AAFactorization, factor!, solve, solve!` therefore resolves cleanly.

## `BlasInt → Int`

`set_num_threads`/`get_num_threads` previously returned `LinearAlgebra.BlasInt`. They now use `Int`, and `APPLE_NTHREADS` is read as `Cint` and widened to `Int`. This removes their LinearAlgebra dependency so they stay in core.

## refactor! (absorbed from #152)

`_sparse_refactor!` passes the matrix to the `_SparseRefactor*` ccall **by pointer via `Ref`** (the by-value form crashes x86_64 with SIGILL; it only worked on arm64 by luck).

## Supersedes / relationship to other PRs

- **Supersedes #155 (closed).**
- **Reworks/absorbs #152**: this PR carries #152's `SparseMatrixCSC` conversions and `refactor!`, relocated into the new three-extension layout. #152 can be closed in favor of this — or, if the maintainer prefers, this can be rebased after #152. Calling it out for the maintainer.

## Sysimage note (gating tests)

The default Julia 1.12 sysimage (`sys.dylib`) **preloads LinearAlgebra and SparseArrays**, so they always appear in `Base.loaded_modules` and the corresponding extensions auto-activate — which is *correct* extension behavior (the trigger module is genuinely loaded). The package graph confirms the contract: AppleAccelerate's only hard dep is `Libdl`; LinearAlgebra/SparseArrays are weakdeps. The gating test detects the sysimage preload and adapts its "absence" assertions accordingly, while always verifying the positive direction (extensions load with their triggers; the dual ext needs both; forwarding is tied to the LinearAlgebra ext).

## Test results (macOS arm64, Julia 1.12.6, Accelerate present)

`Pkg.test()` — full suite green:

| Testset | Pass |
|---|---|
| Extension loading / package contract (new) | 10 |
| Aqua | 11 |
| Array Operations | 644 |
| Complex Array Operations | 60 |
| Signal Processing | 211 |
| Sparse Linear Algebra | 436 |
| Dense Linear Algebra | 3084 |
| Quadrature | 13 |

Also verified: bare `using AppleAccelerate` precompiles & loads with only `Libdl` as a hard dep; dense `A*B`/`lu`/`\` match references once LinearAlgebra is loaded; `get_num_threads`/`set_num_threads` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of the LibAccelerate capability series (follow-up to #151).