### PR TITLE
Fix double-precision complex typedefs in generated raw layer

### DIFF
--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -81,6 +81,33 @@ function strip_out_of_scope_blas!(path)
     return removed
 end
 
+# Post-process: correct the double-precision complex typedefs. Apple's headers define the
+# complex element types via anonymous `_Complex` typedefs (e.g. `typedef _Complex double
+# __double_complex_t;`). Clang.jl mis-resolves these anonymous-`_Complex` typedefs and emits
+# the double-precision ones as `ComplexF32` instead of `ComplexF64`, which would silently give
+# half-width buffers to any double-complex symbol (e.g. `vvcosisin`, `SparseMatrix_Complex_Double`).
+# The single-precision typedefs (`__float_complex_t`, `__SPARSE_float_complex`) are correctly
+# `ComplexF32` and are left untouched. This is a targeted, idempotent rewrite of exactly the two
+# offending `const … = ComplexF32` lines, so the committed output stays deterministic.
+function fix_double_complex_typedefs!(path)
+    lines = readlines(path)
+    fixed = 0
+    for name in ("__double_complex_t", "__SPARSE_double_complex")
+        wrong = "const $name = ComplexF32"
+        right = "const $name = ComplexF64"
+        for i in eachindex(lines)
+            if lines[i] == wrong
+                lines[i] = right
+                fixed += 1
+            end
+        end
+    end
+    write(path, join(lines, "\n") * "\n")
+    return fixed
+end
+
 out_path = joinpath(@__DIR__, "..", "src", "lib", "LibAccelerate.jl")
 removed = strip_out_of_scope_blas!(out_path)
 @info "Stripped $removed out-of-scope BLAS/LAPACK wrappers (forwarded via libblastrampoline)"
+fixed = fix_double_complex_typedefs!(out_path)
+@info "Corrected $fixed double-precision complex typedef(s) (Clang.jl anonymous-_Complex bug)"

--- a/src/lib/LibAccelerate.jl
+++ b/src/lib/LibAccelerate.jl
@@ -2039,7 +2039,7 @@ const DOUBLE_COMPLEX_SPLIT = DSPDoubleSplitComplex
 
 const __float_complex_t = ComplexF32
 
-const __double_complex_t = ComplexF32
+const __double_complex_t = ComplexF64
 
 function vvrecf(arg1, arg2, arg3)
     @ccall libacc.vvrecf(arg1::Ptr{Cfloat}, arg2::Ptr{Cfloat}, arg3::Ptr{Cint})::Cvoid
@@ -2965,7 +2965,7 @@ function Base.propertynames(x::SparseAttributes_t, private::Bool = false)
         end...)
 end
 
-const __SPARSE_double_complex = ComplexF32
+const __SPARSE_double_complex = ComplexF64
 
 struct SparseAttributesComplex_t
     data::NTuple{4, UInt8}

--- a/test/lib_tests.jl
+++ b/test/lib_tests.jl
@@ -1,0 +1,13 @@
+# Lock-in tests for the generated raw ABI layer (src/lib/LibAccelerate.jl).
+#
+# Clang.jl mis-resolves Apple's anonymous `_Complex` typedefs and emitted the
+# double-precision complex element types as ComplexF32. The generator now
+# post-processes these to ComplexF64; these assertions guard against regression
+# (a wrong width would silently hand half-size buffers to double-complex symbols).
+@testset "LibAccelerate complex typedefs" begin
+    @test AppleAccelerate.LibAccelerate.__double_complex_t === ComplexF64
+    @test AppleAccelerate.LibAccelerate.__SPARSE_double_complex === ComplexF64
+    # Single-precision typedefs must stay ComplexF32.
+    @test AppleAccelerate.LibAccelerate.__float_complex_t === ComplexF32
+    @test AppleAccelerate.LibAccelerate.__SPARSE_float_complex === ComplexF32
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ end
 Random.seed!(7)
 N = 1_000
 
+include("lib_tests.jl")
 include("array_tests.jl")
 include("vmath_tests.jl")
 include("complexarray_tests.jl")


### PR DESCRIPTION
## The bug

Clang.jl mis-resolves Apple's anonymous `_Complex` typedefs (e.g. `typedef _Complex double __double_complex_t;`) and emitted the **double-precision** complex element types as `ComplexF32` instead of `ComplexF64` in `src/lib/LibAccelerate.jl`:

```julia
const __double_complex_t      = ComplexF32  # should be ComplexF64
const __SPARSE_double_complex = ComplexF32  # should be ComplexF64
```

The single-precision typedefs (`__float_complex_t`, `__SPARSE_float_complex`) correctly map to `ComplexF32` and are left untouched.

This is currently **latent** — the idiomatic layer hand-avoids these wrappers — but it's a corruption landmine: any future migration of a double-complex symbol (e.g. `vvcosisin` typed `Ptr{__double_complex_t}`, or `SparseMatrix_Complex_Double.data::Ptr{__SPARSE_double_complex}`) would silently get half-width buffers.

## The fix (two parts, reproducible)

1. **Generator post-process** (`gen/generate.jl`): added `fix_double_complex_typedefs!`, mirroring the existing `strip_out_of_scope_blas!` step. It rewrites exactly the two offending `const … = ComplexF32` lines (matched by full name) to `ComplexF64`. Targeted and idempotent, so the committed output stays byte-deterministic.

2. **Matching hand-edit to the committed file** (`src/lib/LibAccelerate.jl`): the same two lines corrected by hand so the file matches what the updated generator would now produce. **No full regen** — the runner SDK differs from the reference SDK, so a full regen would introduce unrelated drift.

## Lock-in test

`test/lib_tests.jl` (wired into `runtests.jl` with a single line) asserts `__double_complex_t === ComplexF64`, `__SPARSE_double_complex === ComplexF64`, and that the single-precision typedefs stay `ComplexF32`.

## Verification

- `Pkg.instantiate()`, clean `using AppleAccelerate`, full `Pkg.test()` — all GREEN (Julia 1.12, macOS arm64). The new typedef testset passes (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)