### PR TITLE
Fix batch of verified correctness & memory-safety bugs

### DIFF
--- a/docs/src/array.md
+++ b/docs/src/array.md
@@ -579,7 +579,8 @@ AppleAccelerate also wraps [vDSP](https://developer.apple.com/documentation/acce
 | `vmul(X, Y)` / `vmul!(result, X, Y)` | Element-wise multiply: `X .* Y` |
 | `vdiv(X, Y)` / `vdiv!(result, X, Y)` | Element-wise divide: `X ./ Y` |
 | `vsmul(X, c)` / `vsmul!(result, X, c)` | Scalar multiply (complex scalar) |
-| `dot(X, Y)` | Unconjugated dot product: `sum(X .* Y)` |
+| `dot(X, Y)` | Conjugated dot product matching `LinearAlgebra.dot`: `sum(conj(X) .* Y)` |
+| `dotu(X, Y)` | Unconjugated (bilinear) dot product: `sum(X .* Y)` |
 | [`zvadd`](@ref AppleAccelerate.zvadd) | Complex addition: `A + B` |
 | [`zvsub`](@ref AppleAccelerate.zvsub) | Complex subtraction: `A - B` |
 | [`zvcmul`](@ref AppleAccelerate.zvcmul) | Conjugate multiply: `conj(A) * B` |

--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -118,6 +118,7 @@ if `n > 1`, use multi-threaded mode. Returns the resulting thread count (from
 warns and returns `1`.
 """
 function set_num_threads(n::Integer)
+    n < 1 && throw(ArgumentError("number of threads must be ≥ 1"))
     ver = get_macos_version()
     if ver === nothing || ver < v"15"
         @warn "The Accelerate threading API requires macOS 15 or later; ignoring" maxlog=1

--- a/src/array.jl
+++ b/src/array.jl
@@ -403,6 +403,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
             """ ->
             function ($f!)(result::Vector{$T}, X::Vector{$T}, Y::Vector{$T})
+                (length(X) == length(Y) == length(result)) ||
+                    throw(DimensionMismatch("result, X and Y must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", f, suff)))(Y, 1, X, 1, result, 1, length(result))
                 return result
             end
@@ -609,6 +611,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, X::Vector{$T}, Y::Vector{$T})
+                (length(X) == length(Y) == length(result)) ||
+                    throw(DimensionMismatch("result, X and Y must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(X,1,Y,1,result,1,length(X))
                 return result
             end
@@ -668,6 +672,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+                (length(A) == length(B) == length(C) == length(result)) ||
+                    throw(DimensionMismatch("result, A, B and C must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(A,1,B,1,C,1,result,1,length(A))
                 return result
             end
@@ -680,6 +686,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
 
     @eval begin
         function venvlp!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+            (length(A) == length(B) == length(C) == length(result)) ||
+                throw(DimensionMismatch("result, A, B and C must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_venvlp", suff)))(A,1,B,1,C,1,result,1,length(A))
             return result
         end
@@ -694,6 +702,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+                (length(A) == length(B) == length(C) == length(D) == length(result)) ||
+                    throw(DimensionMismatch("result, A, B, C and D must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(A,1,B,1,C,1,D,1,result,1,length(A))
                 return result
             end
@@ -706,6 +716,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
 
     @eval begin
         function vpythg!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+            (length(A) == length(B) == length(C) == length(D) == length(result)) ||
+                throw(DimensionMismatch("result, A, B, C and D must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vpythg", suff)))(A,1,B,1,C,1,D,1,result,1,length(A))
             return result
         end
@@ -720,6 +732,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, c::$T)
+                (length(A) == length(B) == length(result)) ||
+                    throw(DimensionMismatch("result, A and B must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(A,1,B,1,Ref(c),result,1,length(A))
                 return result
             end
@@ -732,6 +746,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
 
     @eval begin
         function vsma!(result::Vector{$T}, A::Vector{$T}, b::$T, C::Vector{$T})
+            (length(A) == length(C) == length(result)) ||
+                throw(DimensionMismatch("result, A and C must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vsma", suff)))(A,1,Ref(b),C,1,result,1,length(A))
             return result
         end
@@ -754,6 +770,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
 
     @eval begin
         function vaddsub!(add_result::Vector{$T}, sub_result::Vector{$T}, A::Vector{$T}, B::Vector{$T})
+            (length(A) == length(B) == length(add_result) == length(sub_result)) ||
+                throw(DimensionMismatch("add_result, sub_result, A and B must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vaddsub", suff)))(A,1,B,1,add_result,1,sub_result,1,length(A))
             return (add_result, sub_result)
         end
@@ -787,6 +805,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T})
+                (length(A) == length(B) == length(C) == length(result)) ||
+                    throw(DimensionMismatch("result, A, B and C must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(A,1,B,1,C,1,result,1,length(A))
                 return result
             end
@@ -803,6 +823,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{$T}, D::Vector{$T})
+                (length(A) == length(B) == length(C) == length(D) == length(result)) ||
+                    throw(DimensionMismatch("result, A, B, C and D must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(A,1,B,1,C,1,D,1,result,1,length(A))
                 return result
             end
@@ -816,6 +838,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     # vmsa: D[n] = A[n]*B[n] + c  (2-vector + scalar → 1-vector)
     @eval begin
         function vmsa!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, c::$T)
+            (length(A) == length(B) == length(result)) ||
+                throw(DimensionMismatch("result, A and B must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vmsa", suff)))(A,1,B,1,Ref(c),result,1,length(A))
             return result
         end
@@ -828,6 +852,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     # vsmsb: D[n] = A[n]*b - C[n]  (vector*scalar - vector)
     @eval begin
         function vsmsb!(result::Vector{$T}, A::Vector{$T}, b::$T, C::Vector{$T})
+            (length(A) == length(C) == length(result)) ||
+                throw(DimensionMismatch("result, A and C must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vsmsb", suff)))(A,1,Ref(b),C,1,result,1,length(A))
             return result
         end
@@ -840,6 +866,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     # vsmsma: E[n] = A[n]*b + C[n]*d  (vector*scalar + vector*scalar)
     @eval begin
         function vsmsma!(result::Vector{$T}, A::Vector{$T}, b::$T, C::Vector{$T}, d::$T)
+            (length(A) == length(C) == length(result)) ||
+                throw(DimensionMismatch("result, A and C must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vsmsma", suff)))(A,1,Ref(b),C,1,Ref(d),result,1,length(A))
             return result
         end
@@ -865,11 +893,15 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function dot(X::Vector{$T}, Y::Vector{$T})
+            length(X) == length(Y) ||
+                throw(DimensionMismatch("X and Y must have the same length"))
             val = Ref{$T}(0.0)
             LibAccelerate.$(Symbol(string("vDSP_dotpr", suff)))(X,1,Y,1,val,length(X))
             return val[]
         end
         function distancesq(X::Vector{$T}, Y::Vector{$T})
+            length(X) == length(Y) ||
+                throw(DimensionMismatch("X and Y must have the same length"))
             val = Ref{$T}(0.0)
             LibAccelerate.$(Symbol(string("vDSP_distancesq", suff)))(X,1,Y,1,val,length(X))
             return val[]
@@ -1062,10 +1094,14 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vavlin!(C::Vector{$T}, A::Vector{$T}, weight::$T)
+            length(A) == length(C) ||
+                throw(DimensionMismatch("C and A must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vavlin", suff)))(A,1,Ref(weight),C,1,length(A))
             return C
         end
-        function vavlin(A::Vector{$T}, C::Vector{$T}, weight::$T)
+        # Operand order matches the mutating `vavlin!(C, A, weight)`: C is the
+        # running accumulator, A is the new sample vector.
+        function vavlin(C::Vector{$T}, A::Vector{$T}, weight::$T)
             result = copy(C)
             vavlin!(result, A, weight)
         end
@@ -1140,6 +1176,8 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vintb!(result::Vector{$T}, A::Vector{$T}, B::Vector{$T}, t::$T)
+            (length(A) == length(B) == length(result)) ||
+                throw(DimensionMismatch("result, A and B must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vintb", suff)))(A,1,B,1,Ref(t),result,1,length(A))
             return result
         end

--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -298,8 +298,39 @@ Wraps [`vDSP_zvmgsa`](https://developer.apple.com/documentation/accelerate/vdsp_
 for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
                             (Float64, "D", :DSPDoubleSplitComplex))
     @eval begin
+        @doc """
+            dot(X::Vector{Complex{$($T)}}, Y::Vector{Complex{$($T)}})
+
+        Conjugated complex dot product `sum(conj(X) .* Y)`, matching
+        `LinearAlgebra.dot`. Wraps the conjugating routine
+        [`vDSP_zidotpr`](https://developer.apple.com/documentation/accelerate/vdsp_zidotpr).
+        For the un-conjugated product `sum(X .* Y)` use [`dotu`](@ref).
+        """
         function dot(X::Vector{Complex{$T}}, Y::Vector{Complex{$T}})
             length(X) == length(Y) || throw(DimensionMismatch("dot: X and Y must have equal lengths"))
+            n = length(X)
+            out = $T[0, 0]                 # interleaved [re, im] scalar result
+            GC.@preserve X Y out begin
+                xsplit = _split_view($DSPSplit, pointer(X))
+                ysplit = _split_view($DSPSplit, pointer(Y))
+                osplit = _split_view($DSPSplit, pointer(out))
+                # vDSP_zidotpr conjugates its FIRST argument: result = sum(conj(X) .* Y).
+                LibAccelerate.$(Symbol(string("vDSP_zidotpr", suff)))(
+                      Ref(xsplit), _CSTRIDE, Ref(ysplit), _CSTRIDE, Ref(osplit), n)
+            end
+            return complex(out[1], out[2])
+        end
+
+        @doc """
+            dotu(X::Vector{Complex{$($T)}}, Y::Vector{Complex{$($T)}})
+
+        Un-conjugated complex dot product `sum(X .* Y)` (the "bilinear" dot,
+        without conjugating `X`). Wraps
+        [`vDSP_zdotpr`](https://developer.apple.com/documentation/accelerate/vdsp_zdotpr).
+        For the conjugated product matching `LinearAlgebra.dot` use [`dot`](@ref).
+        """
+        function dotu(X::Vector{Complex{$T}}, Y::Vector{Complex{$T}})
+            length(X) == length(Y) || throw(DimensionMismatch("dotu: X and Y must have equal lengths"))
             n = length(X)
             out = $T[0, 0]                 # interleaved [re, im] scalar result
             GC.@preserve X Y out begin
@@ -714,7 +745,7 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             n = length(X)
             o_re = Vector{$T}(undef, n)
             o_im = Vector{$T}(undef, n)
-            GC.@preserve o_re o_im begin
+            GC.@preserve X o_re o_im begin
                 osplit = $DSPSplit(o_re, o_im)
                 LibAccelerate.$(Symbol(string("vDSP_ctoz", suff)))(
                       pointer(X), 2, Ref(osplit), 1, n)
@@ -724,7 +755,7 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
         function ztoc(re::Vector{$T}, im::Vector{$T})
             n = length(re)
             result = Vector{Complex{$T}}(undef, n)
-            GC.@preserve re im begin
+            GC.@preserve re im result begin
                 isplit = $DSPSplit(re, im)
                 LibAccelerate.$(Symbol(string("vDSP_ztoc", suff)))(
                       Ref(isplit), 1, pointer(result), 2, n)

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -592,10 +592,14 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         Returns: `C`
         """
         function desamp!(C::Vector{$T}, A::Vector{$T}, DF::Int, F::Vector{$T})
-            P = UInt64(length(F))
-            Nout = UInt64(div(length(A) - P, DF) + 1)
-            length(C) >= Nout || error("C must have at least $(Nout) elements")
-            LibAccelerate.$(Symbol(string("vDSP_desamp", suff)))(A,DF,F,C,Nout,P)
+            # Compute the output count in SIGNED arithmetic; converting to
+            # UInt64 first would underflow when length(F) > length(A).
+            length(A) >= length(F) ||
+                error("length(A) ($(length(A))) must be >= length(F) ($(length(F)))")
+            P = length(F)
+            nout = div(length(A) - P, DF) + 1
+            length(C) >= nout || error("C must have at least $(nout) elements")
+            LibAccelerate.$(Symbol(string("vDSP_desamp", suff)))(A, DF, F, C, UInt64(nout), UInt64(P))
             return C
         end
 
@@ -608,6 +612,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         Returns: `Vector{$($T)}`
         """
         function desamp(A::Vector{$T}, DF::Int, F::Vector{$T})
+            length(A) >= length(F) ||
+                error("length(A) ($(length(A))) must be >= length(F) ($(length(F)))")
             P = length(F)
             Nout = div(length(A) - P, DF) + 1
             C = Vector{$T}(undef, Nout)

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -857,10 +857,11 @@ function AASparseMatrix(sparseM::SparseMatrixCSC{T, Int64},
             attributes = istril(sparseM) ? ATT_TRI_LOWER : ATT_TRI_UPPER
         end
     end
-    if attributes in (ATT_TRI_LOWER, ATT_TRI_UPPER) &&
-                    all(diag(sparseM) .== one(eltype(sparseM)))
-        attributes |= ATT_UNIT_TRIANGULAR
-    end
+    # NOTE: we deliberately do NOT auto-tag unit-triangular matrices. libSparse
+    # treats ATT_UNIT_TRIANGULAR as an *implicit* unit diagonal, but we keep the
+    # stored diagonal in the CSC data, so tagging it would double-count the
+    # diagonal in both multiply and solve. The plain ATT_TRIANGULAR path is
+    # correct for stored diagonals.
     c = Clong.(sparseM.colptr .+ -1)
     r = Cint.(sparseM.rowval .+ -1)
     vals = copy(sparseM.nzval)
@@ -897,18 +898,37 @@ _maybe_conjugate(attr::att_type, ::Type{<:Complex}) =
     (ATT_TRANSPOSE | ATT_CONJUGATE_TRANSPOSE)
 _maybe_conjugate(::att_type, ::Type{<:Real}) = false
 
+# Look up a (raw_i, raw_j) entry directly in the stored CSC data, returning
+# `nothing` if there is no stored value at that position.
+function _csc_lookup(M::AASparseMatrix{T}, raw_i::Int, raw_j::Int) where T<:vTypes
+    (startCol, endCol) = (M._colptr[raw_j], M._colptr[raw_j+1]-1) .+ 1
+    rowsInCol = @view M._rowval[startCol:endCol]
+    ind = searchsortedfirst(rowsInCol, raw_i-1)
+    if ind <= length(rowsInCol) && rowsInCol[ind] == raw_i-1
+        return M._nzval[startCol+ind-1]
+    end
+    return nothing
+end
+
 function Base.getindex(M::AASparseMatrix{T}, i::Int, j::Int) where T<:vTypes
     ((size(M)[1] >= i >= 1) && (size(M)[2] >= j >= 1)) || throw(BoundsError(M, (i, j)))
     # (i,j) is the *logical* index; map back to the raw CSC layout.
     attrs = M.matrix.structure.attributes
     transposed = (attrs & ATT_TRANSPOSE) != 0
     raw_i, raw_j = transposed ? (j, i) : (i, j)
-    (startCol, endCol) = (M._colptr[raw_j], M._colptr[raw_j+1]-1) .+ 1
-    rowsInCol = @view M._rowval[startCol:endCol]
-    ind = searchsortedfirst(rowsInCol, raw_i-1)
-    if ind <= length(rowsInCol) && rowsInCol[ind] == raw_i-1
-        val = M._nzval[startCol+ind-1]
+    val = _csc_lookup(M, raw_i, raw_j)
+    if val !== nothing
         return _maybe_conjugate(attrs, T) ? conj(val) : val
+    end
+    # Symmetric/Hermitian matrices store only one triangle, so an element in the
+    # empty triangle must be read from its mirror (j,i), conjugating for
+    # Hermitian-complex.
+    if issymmetric(M) || ishermitian(M)
+        mirrored = _csc_lookup(M, raw_j, raw_i)
+        if mirrored !== nothing
+            herm = (attrs & ATT_KIND_MASK_COMPLEX) == ATT_HERMITIAN
+            return herm ? conj(mirrored) : mirrored
+        end
     end
     return zero(eltype(M))
 end
@@ -1102,6 +1122,7 @@ function solve(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T}) where T<:vTyp
     factor!(aa_fact)
     x = Array{T}(undef, size(aa_fact.matrixObj)[2], size(b)[2:end]...)
     SparseSolve(aa_fact._factorization, b, x)
+    _libsparse_throw(aa_fact._factorization.status, "solve")
     return x
 end
 
@@ -1121,6 +1142,7 @@ function solve!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vT
         )
     factor!(aa_fact)
     SparseSolve(aa_fact._factorization, xb)
+    _libsparse_throw(aa_fact._factorization.status, "solve")
     return xb # written in imitation of KLU.jl, which also returns
 end
 
@@ -1138,5 +1160,6 @@ function LinearAlgebra.ldiv!(x::StridedVecOrMat{T},
         * "$(size(aa_fact.matrixObj)[2]) and $(size(x, 1))"))
     factor!(aa_fact)
     SparseSolve(aa_fact._factorization, b, x)
+    _libsparse_throw(aa_fact._factorization.status, "solve")
     return x
 end

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -640,8 +640,10 @@ for T in (Float32, Float64)
         X::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
         Y::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
 
-        # dot: unconjugated dot product — sum(X .* Y)
-        @test AppleAccelerate.dot(X, Y) ≈ sum(X .* Y)
+        # dot: conjugated dot product matching LinearAlgebra.dot — sum(conj(X) .* Y)
+        @test AppleAccelerate.dot(X, Y) ≈ LinearAlgebra.dot(X, Y) ≈ sum(conj.(X) .* Y)
+        # dotu: unconjugated (bilinear) dot product — sum(X .* Y)
+        @test AppleAccelerate.dotu(X, Y) ≈ sum(X .* Y)
     end
 end
 
@@ -697,7 +699,8 @@ for T in (Float32, Float64)
         C = randn(T, n)
         weight = T(3.0)
 
-        result = AppleAccelerate.vavlin(A, C, weight)
+        # Operand order matches the mutating variant: vavlin(C, A, weight).
+        result = AppleAccelerate.vavlin(C, A, weight)
         expected = (C .* weight .+ A) ./ (weight + 1)
         @test result ≈ expected
 
@@ -1264,6 +1267,27 @@ for T in (Float32, Float64)
         x1 = T[3]
         @test AppleAccelerate.svsub(x1, T(5)) ≈ T[2]
         @test AppleAccelerate.vadd(x1, x1) ≈ T[6]
+    end
+end
+
+# Regression: mutating multi-vector ops used to size the loop from one argument
+# and pass the others as bare pointers, so mismatched lengths read out of bounds
+# with no error. They must now throw DimensionMismatch.
+for T in (Float32, Float64)
+    @testset "length validation throws DimensionMismatch::$T" begin
+        a5 = randn(T, 5); b5 = randn(T, 5); c5 = randn(T, 5); d5 = randn(T, 5)
+        out5 = similar(a5)
+        a3 = randn(T, 3)
+        # Element-wise op (vadd!): mismatched input.
+        @test_throws DimensionMismatch AppleAccelerate.vadd!(out5, a5, a3)
+        # Element-wise op: mismatched output.
+        @test_throws DimensionMismatch AppleAccelerate.vadd!(similar(a3), a5, b5)
+        # Compound op (vma!): result = A*B + C.
+        @test_throws DimensionMismatch AppleAccelerate.vma!(out5, a5, b5, a3)
+        # 4-vector compound op (vmma!).
+        @test_throws DimensionMismatch AppleAccelerate.vmma!(out5, a5, b5, c5, a3)
+        # Reduction (dot).
+        @test_throws DimensionMismatch AppleAccelerate.dot(a5, a3)
     end
 end
 

--- a/test/complexarray_tests.jl
+++ b/test/complexarray_tests.jl
@@ -91,6 +91,13 @@ for T in (Float32, Float64)
         # zrdotpr: complex-real dot
         Br::Vector{T} = randn(T, N)
         @test AppleAccelerate.zrdotpr(A, Br) ≈ sum(A .* Br)
+
+        # Regression: complex `dot` must be conjugated to match LinearAlgebra.dot
+        # (sum(conj(X) .* Y)), and `dotu` exposes the un-conjugated product.
+        @test AppleAccelerate.dot(A, B) ≈ LinearAlgebra.dot(A, B) ≈ sum(conj.(A) .* B)
+        @test AppleAccelerate.dotu(A, B) ≈ sum(A .* B)
+        # The two differ for genuinely complex inputs.
+        @test !(AppleAccelerate.dot(A, B) ≈ AppleAccelerate.dotu(A, B))
     end
 end
 

--- a/test/dsp_tests.jl
+++ b/test/dsp_tests.jl
@@ -503,6 +503,16 @@ end
             @test Cout ≈ Cref
         end
     end
+
+    # Regression: P = UInt64(length(F)); length(A) - P used to underflow when
+    # the filter is longer than the signal, instead of erroring clearly.
+    @testset "desamp errors when filter longer than signal::$T" for T in (Float32, Float64)
+        Ashort = randn(T, 3)
+        Flong = randn(T, 5)
+        @test_throws ErrorException AppleAccelerate.desamp(Ashort, 1, Flong)
+        Cout = Vector{T}(undef, 1)
+        @test_throws ErrorException AppleAccelerate.desamp!(Cout, Ashort, 1, Flong)
+    end
 end
 
 @testset "wiener (Wiener-Levinson)" begin

--- a/test/linalg_tests.jl
+++ b/test/linalg_tests.jl
@@ -57,6 +57,14 @@ end
         @test AppleAccelerate.get_num_threads() == 1
         @test AppleAccelerate.set_num_threads(1) == 1
     end
+    # Regression: set_num_threads(n ≤ 0) used to fall through both branches,
+    # leaving retval == -1 and tripping the BLASSetThreading @assert. It must
+    # reject non-positive thread counts up front. Guarded like the cases above
+    # so it only runs where the threading API is available (macOS ≥ 15).
+    if AppleAccelerate.get_macos_version() >= v"15"
+        @test_throws ArgumentError AppleAccelerate.set_num_threads(0)
+        @test_throws ArgumentError AppleAccelerate.set_num_threads(-1)
+    end
 end
 
 linalg_stdlib_test_path = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")

--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -590,4 +590,43 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, solve
         b = rand(100)
         @test f \ b ≈ jlM \ b
     end
+
+    # Regression: unit-triangular auto-tagging used to OR in ATT_UNIT_TRIANGULAR
+    # while leaving the diagonal stored, so libSparse double-counted the diagonal
+    # (implicit unit diagonal + stored diagonal) in both multiply and solve.
+    @testset "unit-diagonal triangular not double-counted" begin
+        for T in (Float32, Float64)
+            # Lower-triangular with an all-ones diagonal.
+            A = sparse(T[1 0 0; 5 1 0; 2 3 1])
+            aa = AASparseMatrix(A)
+            x = T[2, 3, 4]
+            @test aa * x ≈ A * x
+            # Specifically the case from the bug report.
+            A2 = sparse(T[1 0; 5 1])
+            aa2 = AASparseMatrix(A2)
+            @test aa2 * T[2, 3] ≈ A2 * T[2, 3] ≈ T[2, 13]
+            # Solve must also be correct (not corrupted by an implicit diagonal).
+            f = AAFactorization(aa)
+            @test solve(f, A * x) ≈ x
+        end
+    end
+
+    # Regression: getindex used to read raw CSC and ignore the symmetric/Hermitian
+    # attribute, returning 0 for the un-stored triangle.
+    @testset "getindex mirrors symmetric/Hermitian un-stored triangle" begin
+        # Real symmetric.
+        S = sparse([1.0 2.0 0.0; 2.0 3.0 4.0; 0.0 4.0 5.0])
+        @test issymmetric(S)
+        aaS = AASparseMatrix(S)
+        @test Array(aaS) == Array(S)
+        @test aaS[1, 2] == 2.0
+        @test aaS[2, 3] == 4.0
+
+        # Complex Hermitian: upper triangle is conj of lower.
+        H = sparse(ComplexF64[2 (1+2im) 0; (1-2im) 3 (0-1im); 0 (0+1im) 4])
+        @test ishermitian(H)
+        aaH = AASparseMatrix(H)
+        @test Array(aaH) == Array(H)
+        @test aaH[1, 2] == conj(H[2, 1]) == (1 + 2im)
+    end
 end


### PR DESCRIPTION
This PR fixes a batch of reviewer-verified correctness and memory-safety bugs in the idiomatic wrappers. Full `Pkg.test()` is green (including the new regression tests) on macOS arm64 / Julia 1.12 with Accelerate.

## Bugs fixed

**1. Unit-triangular auto-tagging corrupts `*` / solve (`src/sparse.jl`)**
The `AASparseMatrix` constructor OR-set `ATT_UNIT_TRIANGULAR` for triangular matrices with an all-ones diagonal, but left the diagonal in CSC storage, so libSparse double-counted it (implicit unit diagonal + stored diagonal). E.g. `AASparseMatrix(sparse([1.0 0;5 1]))*[2,3]` gave `[17,13]` instead of `[2,13]`.
- *Fix:* removed the auto-detection branch; the plain `ATT_TRIANGULAR` path is correct for stored diagonals.
- *Test:* lower-triangular unit-diagonal matrix, `aa*x ≈ A*x` (incl. the report case) and `solve` correct.

**2. `getindex` returns 0 for the un-stored triangle of symmetric/Hermitian matrices (`src/sparse.jl`)**
The constructor stores only `tril` and tags symmetric/Hermitian; `getindex` read raw CSC and ignored the attribute.
- *Fix:* when the element is in the empty triangle and the matrix is symmetric/Hermitian, look up the mirror `(j,i)`, conjugating for Hermitian-complex.
- *Test:* `Array(aaSym)==Array(A)` for a real symmetric and a complex Hermitian matrix.

**3. Solve status never checked (`src/sparse.jl`)**
`factor!` checked status via `_libsparse_throw`, but `solve`, `solve!`, and `ldiv!(x,f,b)` did not.
- *Fix:* call `_libsparse_throw(aa_fact._factorization.status, "solve")` before returning from each solve wrapper (no-op on Ok). (No test — no easy failure-path repro.)

**4. vDSP multi-vector ops lack length validation → silent OOB reads (`src/array.jl`)**
Mutating element-wise / compound / reduction ops sized the loop from one argument and passed the rest as bare pointers, so mismatched lengths read out of bounds. Affected: vadd/vsub/vmul/vdiv, vmax/vmin/vmaxmg/vminmg/vdist, vtmerg, the compound ops (vam/vsbm/venvlp/vaam/vsbsbm/vasbm/vpythg/vasm/vsbsm/vsma/vaddsub/vma/vmsb/vmma/vmmsb/vmsa/vsmsb/vsmsma), vintb, and `dot`/`distancesq`.
- *Fix:* added `DimensionMismatch` checks on inputs and output, mirroring the existing vForce wrappers.
- *Test:* `@test_throws DimensionMismatch` for a representative element-wise op, a compound op, a 4-vector op, and `dot`.

**5. Complex `dot` was non-conjugated (`src/complexarray.jl`)**
The complex `dot` used `vDSP_zdotpr` (`sum(X.*Y)`), unlike `LinearAlgebra.dot`.
- *Fix:* `dot` now calls the conjugating `vDSP_zidotpr` (`sum(conj(X).*Y)`); added `dotu` exposing the unconjugated product. Both documented.
- *Test:* `dot ≈ LinearAlgebra.dot`, `dotu ≈ sum(X.*Y)` (existing array-test expectation updated to the corrected semantics).

**6. GC-safety gap in `ctoz` / `ztoc` (`src/complexarray.jl`)**
`ctoz` passed `pointer(X)` without preserving `X`; `ztoc` passed `pointer(result)` without preserving `result`.
- *Fix:* added `X` / `result` to the respective `GC.@preserve` lists.

**7. `desamp!` unsigned underflow (`src/dsp.jl`)**
`P=UInt64(length(F))` then `length(A)-P` underflowed when `length(F)>length(A)`.
- *Fix:* validate `length(A) >= length(F)` first and compute the count in signed arithmetic before converting to `UInt64`.
- *Test:* `@test_throws ErrorException` for a filter longer than the signal (both `desamp` and `desamp!`).

**8. `set_num_threads(n ≤ 0)` trips the wrong assert (`src/AppleAccelerate.jl`)**
`n ≤ 0` skipped both branches, leaving `retval == -1` so the `BLASSetThreading` assert fired.
- *Fix:* `n < 1 && throw(ArgumentError(...))` up front.
- *Test:* `@test_throws ArgumentError` (guarded to macOS ≥ 15, mirroring the existing threading tests).

**9. `vavlin` arg-order inconsistency (`src/array.jl`)**
Allocating `vavlin(A, C, weight)` vs mutating `vavlin!(C, A, weight)`.
- *Fix:* allocating signature is now `vavlin(C, A, weight)`; existing test and doc updated.

## Note for PR #157
The sparse fixes (#1–#3) also need to be carried into open PR #157, which keeps `AASparseMatrix` construction/`getindex` in core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
