### PR TITLE
Fix verified correctness & memory-safety bugs (sparse refactor, conv/spectral OOB, FFT plan size, quadrature)

### DIFF
--- a/ext/AppleAccelerateAbstractFFTsExt.jl
+++ b/ext/AppleAccelerateAbstractFFTsExt.jl
@@ -33,6 +33,16 @@ function _check_vdsp_fft(x::AbstractMatrix)
     return nothing
 end
 
+# Guard plan reuse: a plan built for size N must only run on a matching input.
+# Without this, applying a plan to a different-size array silently produces a
+# wrong-size (garbage) result instead of erroring.
+function _check_plan_input(p, x)
+    size(x) == p.sz || throw(DimensionMismatch(
+        "FFT plan was created for input size $(p.sz), but got input of size $(size(x))"))
+    _check_vdsp_fft(x)
+    return nothing
+end
+
 # Error with a clear message when vDSP can't handle the input.
 function _vdsp_unsupported(x)
     if ndims(x) > 2
@@ -132,17 +142,17 @@ end
 # --- Out-of-place execution ---
 
 function Base.:*(p::VDSPFFTPlan{T,1}, x::AbstractVector) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     AppleAccelerate.fft(convert(Vector{Complex{T}}, x), p.setup)
 end
 
 function Base.:*(p::VDSPBFFTPlan{T,1}, x::AbstractVector) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     AppleAccelerate.bfft(convert(Vector{Complex{T}}, x), p.setup)
 end
 
 function Base.:*(p::VDSPFFTPlan{T,2}, x::AbstractMatrix) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     xc = convert(Matrix{Complex{T}}, x)
     dims = _region_set(p.region)
     if 1 in dims && 2 in dims
@@ -156,7 +166,7 @@ function Base.:*(p::VDSPFFTPlan{T,2}, x::AbstractMatrix) where {T}
 end
 
 function Base.:*(p::VDSPBFFTPlan{T,2}, x::AbstractMatrix) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     xc = convert(Matrix{Complex{T}}, x)
     dims = _region_set(p.region)
     if 1 in dims && 2 in dims
@@ -172,22 +182,22 @@ end
 # --- Out-of-place mul! ---
 
 function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, AppleAccelerate.fft(convert(Vector{Complex{T}}, x), p.setup))
 end
 
 function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPBFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, AppleAccelerate.bfft(convert(Vector{Complex{T}}, x), p.setup))
 end
 
 function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, p * x)
 end
 
 function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPBFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, p * x)
 end
 
@@ -274,17 +284,17 @@ end
 # --- In-place execution ---
 
 function Base.:*(p::VDSPInplaceFFTPlan{T,1}, x::AbstractVector) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     AppleAccelerate.fft!(convert(Vector{Complex{T}}, x), p.setup)
 end
 
 function Base.:*(p::VDSPInplaceBFFTPlan{T,1}, x::AbstractVector) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     AppleAccelerate.bfft!(convert(Vector{Complex{T}}, x), p.setup)
 end
 
 function Base.:*(p::VDSPInplaceFFTPlan{T,2}, x::AbstractMatrix) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     xc = convert(Matrix{Complex{T}}, x)
     dims = _region_set(p.region)
     if 1 in dims && 2 in dims
@@ -297,7 +307,7 @@ function Base.:*(p::VDSPInplaceFFTPlan{T,2}, x::AbstractMatrix) where {T}
 end
 
 function Base.:*(p::VDSPInplaceBFFTPlan{T,2}, x::AbstractMatrix) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     xc = convert(Matrix{Complex{T}}, x)
     dims = _region_set(p.region)
     if 1 in dims && 2 in dims
@@ -312,25 +322,25 @@ end
 # --- In-place mul! ---
 
 function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPInplaceFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, x)
     AppleAccelerate.fft!(convert(Vector{Complex{T}}, y), p.setup)
 end
 
 function LinearAlgebra.mul!(y::AbstractVector{Complex{T}}, p::VDSPInplaceBFFTPlan{T,1}, x::AbstractVector{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, x)
     AppleAccelerate.bfft!(convert(Vector{Complex{T}}, y), p.setup)
 end
 
 function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPInplaceFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, x)
     p * y
 end
 
 function LinearAlgebra.mul!(y::AbstractMatrix{Complex{T}}, p::VDSPInplaceBFFTPlan{T,2}, x::AbstractMatrix{Complex{T}}) where {T}
-    _check_vdsp_fft(x)
+    _check_plan_input(p, x)
     copyto!(y, x)
     p * y
 end

--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -672,8 +672,13 @@ for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
             xn = length(X)
             kn = length(K)
             rn = length(result)
-            # Pad X with (kn-1) leading and kn trailing zeros, matching the real conv path.
-            xpad = zeros(Complex{$T}, xn + 2kn - 1)
+            rn >= xn + kn - 1 ||
+                error("'result' must have at least length(X) + length(K) - 1 elements")
+            # vDSP reads rn + kn - 1 input elements, so size the zero-padding from
+            # rn (not the natural result length) to keep reads in-bounds for an
+            # oversized `result` buffer: (kn-1) leading + X + trailing zeros, for a
+            # total padded length of rn + 2kn - 1.
+            xpad = zeros(Complex{$T}, rn + 2kn - 1)
             copyto!(xpad, kn, X, 1, xn)
             GC.@preserve xpad K result begin
                 xsplit = _split_view($DSPSplit, pointer(xpad))

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -65,7 +65,11 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             if (rsize < xsize + ksize - 1)
                 error("'result' must have at least length(X) + length(K) - 1 elements")
             end
-            xpadded::Vector{$T} = [zeros($T, ksize-1); X; zeros($T, ksize)]
+            # vDSP reads rsize + ksize - 1 input elements (not just the minimum),
+            # so size the zero-padding from rsize, not the natural result length,
+            # to keep reads in-bounds for an oversized `result` buffer. Total
+            # padded length = rsize + 2*ksize - 1 (front pad ksize-1).
+            xpadded::Vector{$T} = [zeros($T, ksize-1); X; zeros($T, rsize + ksize - xsize)]
             LibAccelerate.$(Symbol(string("vDSP_conv", suff)))(xpadded,1,pointer(K, ksize),-1,result,1,rsize,ksize)
             return result
         end
@@ -110,7 +114,10 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             if (rsize < xsize + ysize - 1)
                 error("'result' must have at least length(X) + length(Y) - 1 elements")
             end
-            xpadded::Vector{$T} = [zeros($T, ysize-1); X; zeros($T, ysize)]
+            # vDSP reads rsize + ysize - 1 input elements; size the zero-padding
+            # from rsize so an oversized `result` buffer stays in-bounds. Total
+            # padded length = rsize + 2*ysize - 1 (front pad ysize-1).
+            xpadded::Vector{$T} = [zeros($T, ysize-1); X; zeros($T, rsize + ysize - xsize)]
             LibAccelerate.$(Symbol(string("vDSP_conv", suff)))(xpadded,1,Y,1,result,1,rsize,ysize)
             return result
         end
@@ -400,6 +407,8 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
         """
         function zaspec!(C::Vector{$T}, A::Vector{Complex{$T}})
             n = length(A)
+            length(C) >= n || throw(DimensionMismatch(
+                "zaspec!: output `C` must have at least length(A) = $n elements; got $(length(C))"))
             realp = $T.(real.(A))
             imagp = $T.(imag.(A))
             GC.@preserve realp imagp begin
@@ -422,6 +431,9 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
         """
         function zcoher!(D::Vector{$T}, A::Vector{$T}, B::Vector{$T}, C::Vector{Complex{$T}})
             n = length(A)
+            (length(B) >= n && length(C) >= n && length(D) >= n) || throw(DimensionMismatch(
+                "zcoher!: `B`, `C`, and `D` must each have at least length(A) = $n elements; " *
+                "got B=$(length(B)), C=$(length(C)), D=$(length(D))"))
             cr = $T.(real.(C))
             ci = $T.(imag.(C))
             GC.@preserve cr ci begin
@@ -444,6 +456,9 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
         """
         function ztrans!(C::Vector{Complex{$T}}, A::Vector{$T}, B::Vector{Complex{$T}})
             n = length(A)
+            (length(B) >= n && length(C) >= n) || throw(DimensionMismatch(
+                "ztrans!: `B` and `C` must each have at least length(A) = $n elements; " *
+                "got B=$(length(B)), C=$(length(C))"))
             br = $T.(real.(B))
             bi = $T.(imag.(B))
             cr = Vector{$T}(undef, n)
@@ -472,6 +487,9 @@ for (T, suff, SC) in ((Float32, "", :DSPSplitComplex), (Float64, "D", :DSPDouble
         """
         function zcspec!(C::Vector{Complex{$T}}, A::Vector{Complex{$T}}, B::Vector{Complex{$T}})
             n = length(A)
+            (length(B) >= n && length(C) >= n) || throw(DimensionMismatch(
+                "zcspec!: `B` and `C` must each have at least length(A) = $n elements; " *
+                "got B=$(length(B)), C=$(length(C))"))
             ar = $T.(real.(A))
             ai = $T.(imag.(A))
             br = $T.(real.(B))

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -17,17 +17,44 @@ using .LibAccelerate:
     QUADRATURE_INTEGRATE_QAG,
     QUADRATURE_INTEGRATE_QAGS
 
+# Mutable box passed to the C trampoline via the user-pointer. Holds the Julia
+# integrand and a slot for any exception it throws, so the error can be carried
+# back across the C QUADPACK frames and rethrown in `integrate` (throwing
+# directly through the C frames is undefined behavior).
+mutable struct _QuadratureBox
+    f::Any
+    err::Any
+end
+
 # Top-level (non-closure) callback for Accelerate's batched integrand evaluation. We recover
 # the Julia integrand from the C `fun_arg` user-pointer rather than closing over it, because
 # closure `@cfunction` is unsupported on macOS/aarch64 before Julia 1.12; this trampoline
-# works on all supported platforms. `arg` points to a `Ref{Any}` boxing the integrand.
+# works on all supported platforms. `arg` points to a `Ref{Any}` boxing a `_QuadratureBox`.
 function _quadrature_trampoline(arg::Ptr{Cvoid}, n::Csize_t,
                                 x::Ptr{Cdouble}, y::Ptr{Cdouble})
-    f = unsafe_pointer_to_objref(arg)[]
+    box = unsafe_pointer_to_objref(arg)[]::_QuadratureBox
     xs  = unsafe_wrap(Array, x, (Int(n),))
     out = unsafe_wrap(Array, y, (Int(n),))
+    # If a previous batch already errored, stop evaluating; just fill sentinels.
+    if box.err !== nothing
+        @inbounds for i in 1:Int(n)
+            out[i] = NaN
+        end
+        return nothing
+    end
+    f = box.f
     @inbounds for i in 1:Int(n)
-        out[i] = f(xs[i])
+        try
+            out[i] = f(xs[i])
+        catch e
+            # Capture the first error and write a sentinel; do NOT let the
+            # exception unwind through the C caller. `integrate` rethrows it.
+            box.err = e
+            for j in i:Int(n)
+                out[j] = NaN
+            end
+            return nothing
+        end
     end
     return nothing
 end
@@ -43,6 +70,11 @@ using Apple's Accelerate Quadrature library (a C port of QUADPACK).
 in batches, which is handled internally.
 
 For `integrator=:qags`, one or both bounds may be infinite (`±Inf`).
+
+For `integrator=:qag`, `qag_points` selects the Gauss-Kronrod rule and must be one
+of `15`, `21`, `31`, `41`, `51`, `61` (or `0` for the library default). Any other
+value throws an `ArgumentError` (the underlying library would otherwise silently
+return `value = 0.0`).
 
 Returns a named tuple `(value, abserr, status)` where `value` is the integral
 estimate, `abserr` is the estimated absolute error, and `status` is the
@@ -67,13 +99,19 @@ function integrate(f, a::Real, b::Real;
            integrator === :qags ? QUADRATURE_INTEGRATE_QAGS :
            throw(ArgumentError("unknown integrator $(repr(integrator)); use :qng, :qag, or :qags"))
 
-    # Pass the integrand to the top-level trampoline via the C user-pointer. `fbox` boxes `f`
-    # in a mutable Ref so we can take its address (pointer_from_objref needs a mutable object,
-    # and works for any callable incl. singletons like `sin`); GC.@preserve keeps it alive
-    # across the ccall.
+    # For QAG, only the six Gauss-Kronrod rules below are valid; any other nonzero
+    # value makes the library silently return value = 0.0, so reject it up front.
+    qag_points in (0, 15, 21, 31, 41, 51, 61) ||
+        throw(ArgumentError("qag_points must be one of 0 (default), 15, 21, 31, 41, " *
+                            "51, 61; got $(qag_points)"))
+
+    # Pass the integrand to the top-level trampoline via the C user-pointer. `fbox` boxes a
+    # mutable `_QuadratureBox` in a Ref so we can take its address (pointer_from_objref needs a
+    # mutable object); GC.@preserve keeps it alive across the ccall. The box also carries back
+    # any exception the integrand throws so we can rethrow it without unwinding through C.
     cb = @cfunction(_quadrature_trampoline, Cvoid,
                     (Ptr{Cvoid}, Csize_t, Ptr{Cdouble}, Ptr{Cdouble}))
-    fbox = Ref{Any}(f)
+    fbox = Ref{Any}(_QuadratureBox(f, nothing))
     fun = Ref(quadrature_integrate_function(cb, pointer_from_objref(fbox)))
     opts = Ref(quadrature_integrate_options(
         intg, Float64(abstol), Float64(reltol),
@@ -85,6 +123,11 @@ function integrate(f, a::Real, b::Real;
         quadrature_integrate(fun, Float64(a), Float64(b), opts,
                              status, abserr, Csize_t(0), C_NULL)
     end
+
+    # If the integrand threw during evaluation, surface that error now (rather
+    # than returning a meaningless value/status).
+    captured = (fbox[]::_QuadratureBox).err
+    captured === nothing || throw(captured)
 
     return (value = value, abserr = abserr[], status = status[])
 end

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -1051,6 +1051,12 @@ const _REFACTOR_SYM = Dict(
     (Cdouble,    :Symmetric) => :_SparseRefactorSymmetric_Double,
     (ComplexF32, :Symmetric) => :_SparseRefactorSymmetric_Complex_Float,
     (ComplexF64, :Symmetric) => :_SparseRefactorSymmetric_Complex_Double,
+    # Complex-Hermitian Cholesky/LDLT refactor: libSparse's *Symmetric_Complex*
+    # kernels reject Hermitian factorizations ("only applies to SparseSymmetric
+    # matrices"), so a separate Hermitian family is required. (Real Hermitian ==
+    # symmetric, so real types stay in the :Symmetric family above.)
+    (ComplexF32, :Hermitian) => :_SparseRefactorHermitian_Complex_Float,
+    (ComplexF64, :Hermitian) => :_SparseRefactorHermitian_Complex_Double,
     (Cfloat,     :QR)        => :_SparseRefactorQR_Float,
     (Cdouble,    :QR)        => :_SparseRefactorQR_Double,
     (ComplexF32, :QR)        => :_SparseRefactorQR_Complex_Float,
@@ -1289,7 +1295,12 @@ function refactor!(aa_fact::AAFactorization{T}, A::AASparseMatrix{T}) where T<:v
         "pattern): factored matrix has $(length(old._nzval)), new matrix has " *
         "$(length(A._nzval))"))
 
-    family = _refactor_family(aa_fact._factorization.symbolicFactorization.type)
+    # The symbolic factorization's `attributes` field is zeroed, so the
+    # Hermitian-vs-symmetric distinction (needed only for complex Cholesky/LDLT
+    # refactor, which has dedicated Hermitian kernels) must come from the NEW
+    # matrix `A`. Real Hermitian == symmetric, so real types stay :Symmetric.
+    family = (T <: Complex && ishermitian(A)) ? :Hermitian :
+             _refactor_family(aa_fact._factorization.symbolicFactorization.type)
     nfopts = Ref(SparseNumericFactorOptions(T))
     factref = Ref(aa_fact._factorization)
     GC.@preserve A begin

--- a/test/complexarray_tests.jl
+++ b/test/complexarray_tests.jl
@@ -120,6 +120,18 @@ for T in (Float32, Float64)
         # Numerical correctness: vDSP_zconv applies the kernel without reversal
         # (correlation-style), matching DSP.conv with a reversed kernel.
         @test result ≈ DSP.conv(X, reverse(K)) atol=T(1e-3)
+
+        # Regression: an oversized `result` buffer must not make vDSP read past
+        # the zero-padded input (padding is sized from length(result)).
+        extra = 7
+        big = fill(Complex{T}(NaN), length(result) + extra)
+        AppleAccelerate.zconv!(big, X, K)
+        @test big[1:length(result)] ≈ result atol=T(1e-3)
+        @test !any(isnan, big)
+
+        # Too-short result must still be rejected.
+        @test_throws ErrorException AppleAccelerate.zconv!(
+            similar(big, length(X) + length(K) - 2), X, K)
     end
 end
 

--- a/test/dsp_tests.jl
+++ b/test/dsp_tests.jl
@@ -1,11 +1,20 @@
 @testset "Signal Processing" begin
 
-@testset "DCT::Float32" begin
-    r=rand(Float32,2^16)
-    d1=DSP.dct(r)
-    plan_accel = AppleAccelerate.plan_dct(length(r), 2)
-    d2=AppleAccelerate.dct(r, plan_accel)
-    @test norm(d1[2]/d2[2]*d2[2:end]-d1[2:end])≤1000eps(Float32)
+@testset "DCT" begin
+    # vDSP's DCT-II is unnormalized relative to DSP's orthonormal DCT-II by a
+    # *fixed* (data-independent) factor: out[1] = sqrt(N)*ortho[1] and
+    # out[k] = sqrt(N/2)*ortho[k] for k > 1. Compare against that fixed scaling
+    # directly (not a data-derived ratio, which would mask scale-factor errors).
+    @testset "$T" for T in (Float32, Float64)
+        n = 2^12
+        r = rand(T, n)
+        d_ortho = DSP.dct(Float64.(r))               # orthonormal reference
+        scale = fill(sqrt(n / 2), n); scale[1] = sqrt(n)
+        ref = Float64.(d_ortho) .* scale
+        # AppleAccelerate.dct only takes Float32; cast the input for both paths.
+        got = AppleAccelerate.dct(Float32.(r))
+        @test Float64.(got) ≈ ref rtol = (T == Float32 ? 1e-3 : 1e-4)
+    end
 end
 
 @testset "fft::Float64" begin
@@ -349,6 +358,23 @@ end
         @test_throws ArgumentError plan_fft!(randn(ComplexF64, 4, 4, 4))
     end
 
+    @testset "wrong-size input to a plan throws" begin
+        # A plan built for size N must reject a differently-sized input rather
+        # than silently returning a wrong-size result.
+        p = plan_fft(randn(ComplexF64, 64))
+        @test_throws DimensionMismatch p * randn(ComplexF64, 16)
+        y = Vector{ComplexF64}(undef, 16)
+        @test_throws DimensionMismatch mul!(y, p, randn(ComplexF64, 16))
+
+        # In-place plan: same guard.
+        pin = plan_fft!(randn(ComplexF64, 64))
+        @test_throws DimensionMismatch pin * randn(ComplexF64, 16)
+
+        # 2D plan rejects wrong matrix size.
+        p2 = plan_fft(randn(ComplexF64, 16, 16))
+        @test_throws DimensionMismatch p2 * randn(ComplexF64, 8, 8)
+    end
+
     @testset "In-place fft!" begin
         x = randn(ComplexF64, 256)
         p = plan_fft!(x)
@@ -382,6 +408,27 @@ for T in (Float32,  Float64)
             @eval fb = $f
             @eval fa = AppleAccelerate.$f
             @test fa(X) ≈ fb(X, copy(X))
+        end
+
+        # Regression: an oversized `result` buffer must not cause vDSP to read
+        # past the zero-padded input (the padding is sized from length(result)).
+        @testset "oversized result buffer (no OOB)::$T" begin
+            K = randn(T, 5)
+            natural = AppleAccelerate.conv(X, K)         # length N + 5 - 1
+            extra = 7
+            big = fill(T(NaN), length(natural) + extra)  # deliberately too long
+            AppleAccelerate.conv!(big, X, K)
+            # Valid region must match the natural-length convolution; the result
+            # is well-defined for all length(result) elements (the extra tail
+            # reads from the in-bounds zero padding, so it must not be NaN).
+            @test big[1:length(natural)] ≈ natural
+            @test !any(isnan, big)
+
+            # xcorr! with an oversized buffer likewise stays in-bounds.
+            bigx = fill(T(NaN), length(natural) + extra)
+            AppleAccelerate.xcorr!(bigx, X, Y[1:5])
+            @test bigx[1:length(natural)] ≈ AppleAccelerate.xcorr(X, Y[1:5])
+            @test !any(isnan, bigx)
         end
     end
 end
@@ -430,6 +477,19 @@ end
     @test Y[2] ≈ 6 .* x
     # numelem larger than the channel length must be rejected, not read OOB
     @test_throws ErrorException AppleAccelerate.biquadm([copy(x), copy(x)], 9, setup)
+end
+
+@testset "Multi-channel Biquad layout::Float64" begin
+    # Float64 counterpart of the multichannel test above.
+    x64 = Float64.(collect(1:8))
+    c64 = [1.0,0,0,0,0,  2.0,0,0,0,0,
+           1.0,0,0,0,0,  3.0,0,0,0,0]
+    setup64 = AppleAccelerate.biquadm_create(c64, 2, 2, Float64)
+    Y64 = AppleAccelerate.biquadm([copy(x64), copy(x64)], 8, setup64)
+    @test Y64[1] ≈ x64
+    @test Y64[2] ≈ 6 .* x64
+    # numelem larger than the channel length must be rejected, not read OOB
+    @test_throws ErrorException AppleAccelerate.biquadm([copy(x64), copy(x64)], 9, setup64)
 end
 
 @testset "deq22 (recursive filter)" begin
@@ -689,6 +749,23 @@ end
             AppleAccelerate.zcspec!(C2, A, B)
             AppleAccelerate.zcspec!(C2, A, B)
             @test C2 ≈ 2 .* (conj.(A) .* B)
+        end
+
+        # Regression: a short sibling array must throw DimensionMismatch rather
+        # than make vDSP read out of bounds.
+        @testset "short-array validation::$T" begin
+            n = 64
+            A   = CT.(randn(n) .+ im .* randn(n))
+            Ar  = abs.(randn(T, n)) .+ T(0.01)
+            Br  = abs.(randn(T, n)) .+ T(0.01)
+            Cc  = CT.(randn(n) .+ im .* randn(n))
+            short_real = zeros(T, n - 1)
+            short_cplx = zeros(CT, n - 1)
+
+            @test_throws DimensionMismatch AppleAccelerate.zaspec!(short_real, A)
+            @test_throws DimensionMismatch AppleAccelerate.zcoher!(short_real, Ar, Br, Cc)
+            @test_throws DimensionMismatch AppleAccelerate.ztrans!(short_cplx, Ar, Cc)
+            @test_throws DimensionMismatch AppleAccelerate.zcspec!(short_cplx, A, Cc)
         end
     end
 end

--- a/test/quadrature_tests.jl
+++ b/test/quadrature_tests.jl
@@ -1,6 +1,10 @@
 using AppleAccelerate: integrate
 using AppleAccelerate.LibAccelerate: QUADRATURE_SUCCESS
 
+# Custom exception type for the throwing-integrand test (structs can't be
+# defined in local/testset scope).
+struct _QuadTestError <: Exception end
+
 @testset "Quadrature" begin
     @testset "polynomial / smooth (finite interval)" begin
         r = integrate(x -> x^2, 0, 1)
@@ -32,5 +36,25 @@ using AppleAccelerate.LibAccelerate: QUADRATURE_SUCCESS
             @test integrate(cos, 0, π/2; integrator = intg).value ≈ 1.0 atol=1e-7
         end
         @test_throws ArgumentError integrate(sin, 0, 1; integrator = :nope)
+    end
+
+    @testset "qag_points validation" begin
+        # Valid Gauss-Kronrod rules integrate correctly.
+        for pts in (15, 21, 31, 41, 51, 61)
+            @test integrate(cos, 0, π/2; integrator = :qag, qag_points = pts).value ≈ 1.0 atol=1e-7
+        end
+        # An invalid rule must throw (the library would otherwise return 0.0).
+        @test_throws ArgumentError integrate(cos, 0, π/2; integrator = :qag, qag_points = 7)
+        @test_throws ArgumentError integrate(cos, 0, π/2; integrator = :qag, qag_points = 100)
+    end
+
+    @testset "throwing integrand surfaces a Julia exception" begin
+        # The integrand error must come back as a Julia exception (not a crash
+        # from unwinding through the C QUADPACK frames).
+        @test_throws DomainError integrate(x -> x < 0.5 ? x : throw(DomainError(x)), 0, 1)
+        # Custom exception type is preserved.
+        @test_throws _QuadTestError integrate(x -> throw(_QuadTestError()), 0, 1)
+        # Subsequent integrate calls still work (no corrupted state).
+        @test integrate(x -> x^2, 0, 1).value ≈ 1/3 atol=1e-8
     end
 end

--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -385,6 +385,22 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, refac
             @test_throws ArgumentError solve!(f, xb_matrix)
         end
 
+        @testset "lu! on unfactored F throws" begin
+            A = sprandn(6, 6, 0.4) + 10I
+            # refactor!-style spellings require F to already hold a factorization.
+            @test_throws ArgumentError lu!(AAFactorization(A), A)
+        end
+
+        @testset "solve!(f, B::Matrix) square" begin
+            N = 5
+            A = sprandn(N, N, 0.5) + N * I
+            f = AAFactorization(A)
+            X = rand(N, 3)
+            B = A * X
+            solve!(f, B)             # square system: B overwritten with solution
+            @test isapprox(B, X; rtol = 1e-8)
+        end
+
         @testset "Cholesky" begin
             # create a random symmetric positive-definite matrix A.
             N = 4
@@ -699,6 +715,91 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, refac
             factor!(fl, AppleAccelerate.SparseFactorizationLDLT)
             ldlt!(fl, AASparseMatrix(S2))
             @test isapprox(solve(fl, b), Matrix(S2) \ b; rtol = 1e-7)
+        end
+
+        # Complex sparse support (and the Hermitian refactor kernels) require
+        # macOS 15.5+. Mirrors the real refactor coverage above. Regression for
+        # the Hermitian-refactor crash: libSparse's *Symmetric_Complex* refactor
+        # rejects Hermitian factorizations, so Cholesky/LDLT refactor of a complex
+        # Hermitian matrix must route through the dedicated Hermitian kernels.
+        something(AppleAccelerate.get_macos_version(), v"0.0.0") >= v"15.5" &&
+        @testset "complex $T" for T in (ComplexF64, ComplexF32)
+            rtol = T == ComplexF32 ? 1e-2 : 1e-7
+            N = 12
+
+            # Build a Hermitian positive-definite matrix and a same-pattern variant.
+            herm(B) = sparse(Hermitian(B + B' + N * I))
+            B1 = sprandn(T, N, N, 0.3)
+            H1 = herm(B1)
+            @test ishermitian(H1) && !issymmetric(H1)
+            # Same sparsity pattern, scaled values (scaling preserves Hermitian-ness
+            # and the stored pattern).
+            H2 = copy(H1); H2.nzval .*= T(1.3)
+            @test ishermitian(H2)
+            b = rand(T, N)
+
+            @testset "Hermitian Cholesky refactor" begin
+                f = cholesky(AASparseMatrix(H1))
+                cholesky!(f, AASparseMatrix(H2))
+                xref = solve(f, b)
+                xfresh = solve(cholesky(AASparseMatrix(H2)), b)
+                @test isapprox(xref, xfresh; rtol = rtol)
+                @test isapprox(Matrix(H2) * xref, b; rtol = 10 * rtol)
+            end
+
+            @testset "complex LU refactor" begin
+                # Square, non-Hermitian, diagonally dominant.
+                A1 = sprandn(T, N, N, 0.3) + T(N) * I
+                @test !ishermitian(A1)
+                A2 = copy(A1); A2.nzval .*= T(1.4)
+                f = lu(AASparseMatrix(A1))
+                refactor!(f, AASparseMatrix(A2))
+                xref = solve(f, b)
+                xfresh = solve(lu(AASparseMatrix(A2)), b)
+                @test isapprox(xref, xfresh; rtol = rtol)
+                @test isapprox(Matrix(A2) * xref, b; rtol = 10 * rtol)
+            end
+
+            @testset "complex QR refactor" begin
+                A1 = sprandn(T, N, N, 0.3) + T(N) * I
+                A2 = copy(A1); A2.nzval .*= T(1.2)
+                f = qr(AASparseMatrix(A1))
+                refactor!(f, AASparseMatrix(A2))
+                xref = solve(f, b)
+                xfresh = solve(qr(AASparseMatrix(A2)), b)
+                @test isapprox(xref, xfresh; rtol = rtol)
+                @test isapprox(Matrix(A2) * xref, b; rtol = 10 * rtol)
+            end
+        end
+
+        # Hermitian LDLT refactor must route through the dedicated Hermitian
+        # kernel (the Symmetric_Complex kernel rejects Hermitian factorizations).
+        # This is verified in a *fresh subprocess*: Apple's libSparse has a
+        # process-global defect where any prior complex-Hermitian factorization
+        # (e.g. the Hermitian Cholesky factorize exercised earlier in this suite)
+        # poisons a later complex-Hermitian LDLT refactor, crashing inside
+        # libSparse's own `_SparseGetWorkspaceRequired`. Isolating it in its own
+        # process avoids that libSparse bug while still covering our routing fix.
+        something(AppleAccelerate.get_macos_version(), v"0.0.0") >= v"15.5" &&
+        @testset "Hermitian LDLT refactor (isolated subprocess)" begin
+            code = """
+            using AppleAccelerate, LinearAlgebra, SparseArrays
+            import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, solve
+            T = ComplexF64; N = 12
+            B1 = sprandn(T, N, N, 0.3)
+            H1 = sparse(Hermitian(B1 + B1' + N*I))
+            H2 = copy(H1); H2.nzval .*= T(1.3)
+            b = rand(T, N)
+            f = AAFactorization(AASparseMatrix(H1))
+            factor!(f, AppleAccelerate.SparseFactorizationLDLT)
+            ldlt!(f, AASparseMatrix(H2))                 # Hermitian LDLT refactor
+            xref = solve(f, b)
+            ok = isapprox(Matrix(H2) * xref, b; rtol = 1e-6)
+            exit(ok ? 0 : 1)
+            """
+            proj = Base.active_project()
+            p = run(ignorestatus(`$(Base.julia_cmd()) --project=$(proj) -e $code`))
+            @test p.exitcode == 0
         end
     end
 


### PR DESCRIPTION
Fixes six reviewer-verified correctness / memory-safety bugs plus their regression tests, and folds in a few test improvements. Touches only the hand-written layer (the auto-generated `src/lib/LibAccelerate.jl` is untouched).

## Fixes

1. **Complex-Hermitian refactor crash** (`src/sparse.jl`). Added a `:Hermitian` refactor family mapping complex Cholesky/LDLT refactor to `_SparseRefactorHermitian_Complex_{Float,Double}`; the previously-used `*Symmetric_Complex*` kernels reject Hermitian factorizations ("only applies to SparseSymmetric matrices"). `refactor!` now picks the family from the **new** matrix `A` (`T<:Complex && ishermitian(A) ? :Hermitian : _refactor_family(...)`) because the symbolic factorization's `attributes` are zeroed. Real Hermitian == symmetric, so real types stay `:Symmetric`. Reaches users via `refactor!`, `cholesky!(f,A)`, `ldlt!(f,A)`.
   - **Tests:** complex Hermitian Cholesky refactor, complex LU refactor, complex QR refactor (ComplexF64 + ComplexF32), each asserting the refactored solve matches a fresh factorization. The Hermitian **LDLT** refactor regression runs in an **isolated subprocess**: Apple's libSparse has a process-global defect where any prior complex-Hermitian factorization (e.g. the Hermitian Cholesky factorize exercised earlier in the suite) poisons a later complex-Hermitian LDLT refactor, crashing inside libSparse's own `_SparseGetWorkspaceRequired`. The subprocess keeps the suite green while still covering our routing fix.

2. **`conv!`/`xcorr!`/`zconv!` OOB read** (`src/dsp.jl`, `src/complexarray.jl`). vDSP reads `length(result)+P-1` input elements, but the zero-padding was sized from the *minimum* result length, so an oversized `result` buffer read out of bounds. Padding is now sized from `length(result)`; `zconv!` also gained the missing minimum-length validation.
   - **Test:** an oversized `result` buffer yields correct values in the valid region with no NaN/OOB.

3. **Spectral routines missing length validation** (`src/dsp.jl`: `zaspec!`/`zcoher!`/`ztrans!`/`zcspec!`). Now validate every participating array has length `>= n`, throwing `DimensionMismatch`.
   - **Test:** a short sibling array throws.

4. **AbstractFFTs plan input-size not validated** (`ext/AppleAccelerateAbstractFFTsExt.jl`). New `_check_plan_input(p, x)` asserts `size(x) == p.sz` before executing, so a plan applied to a wrong-size array throws `DimensionMismatch` instead of silently returning a wrong-size result.
   - **Test:** wrong-size input to vector / in-place / 2D plans throws.

5. **Quadrature `qag_points` validation** (`src/quadrature.jl`). Validates `qag_points in (0,15,21,31,41,51,61)` with an `ArgumentError` before the ccall (other values silently return `value=0.0`); documented the allowed set.
   - **Test:** an invalid `qag_points` throws.

6. **Quadrature integrand-throws-across-C-frame** (`src/quadrature.jl`). The trampoline now wraps per-point evaluation in `try`/`catch`, writes a `NaN` sentinel, and captures the exception in a mutable box; `integrate` rethrows it after the ccall instead of unwinding through the C QUADPACK frames.
   - **Test:** a throwing integrand surfaces a Julia exception (incl. custom types); subsequent `integrate` calls still work.

## Test improvements

- DCT test now compares `AppleAccelerate.dct` directly against orthonormal `DSP.dct` with the fixed (data-independent) DCT-II scaling, catching scale-factor errors the old ratio-normalization masked; added a Float64 case.
- Added a **Float64** multichannel `biquadm` case plus its `numelem > length` OOB-reject (was Float32-only).
- Added `@test_throws ArgumentError lu!(AAFactorization(A), A)` on an unfactored `F`, and a successful `solve!(f, B::Matrix)` for a square system.

## Verification

`Pkg.instantiate()` then full `Pkg.test()` GREEN on macOS arm64 / Julia 1.12 with Accelerate present (all suites pass, including all new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)