### PR TITLE
Test: bring src/sparse.jl to 100% coverable-line coverage

### DIFF
--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -371,6 +371,23 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, refac
             @test_throws DimensionMismatch LinearAlgebra.ldiv!(wrong_x, f, good_b)
         end
 
+        @testset "ldiv!(x, f, b) writes solution" begin
+            # Exercises the successful body of the 3-arg ldiv!(x, f, b), checked
+            # against the dense solve. Vector and matrix RHS, square system.
+            N = 6
+            A = sprandn(N, N, 0.5) + N * I
+            f = AAFactorization(A)
+            x0 = rand(N); b = A * x0
+            x = similar(x0)
+            ret = LinearAlgebra.ldiv!(x, f, b)
+            @test ret === x
+            @test isapprox(x, Matrix(A) \ b; rtol = 1e-8)
+
+            X0 = rand(N, 3); B = A * X0
+            X = similar(X0)
+            @test isapprox(LinearAlgebra.ldiv!(X, f, B), Matrix(A) \ B; rtol = 1e-8)
+        end
+
         @testset "ArgumentError for in-place solve" begin
             N = 4
             M = 5


### PR DESCRIPTION
## Summary

Maximizes coverage of `src/sparse.jl` and cross-validates the sparse ops against `SparseArrays` + dense `LinearAlgebra`.

**Coverage (code-coverage=user, `Random.seed!(7)`, full `sparse_tests.jl`):**
- Baseline: **98.21%** (219/223 coverable lines)
- Final: **100.0%** (223/223 coverable lines)

## What was uncovered at baseline

Only the **success body of the 3-argument `LinearAlgebra.ldiv!(x, f, b)`** (`src/sparse.jl:1243-1246`): the existing suite hit only its `DimensionMismatch` error branches, never the path that factors, solves into the caller-supplied output, and returns it.

## Additions

A `"ldiv!(x, f, b) writes solution"` testset that:
- drives both a **vector** and a **matrix** RHS on a square, diagonally-dominant system,
- asserts the return value **aliases** the output buffer (`ret === x`),
- cross-validates against the dense reference `Matrix(A) \ b` within `rtol = 1e-8`.

## References used for cross-validation

The suite as a whole validates every op against references: `AASparseMatrix` `*`/`muladd!` (scaled, vector + matrix RHS) vs `Matrix(A)*x`; `transpose`/`adjoint` vs dense; `getindex`/`Array`/`SparseMatrixCSC` round-trips (ordinary/transpose/symmetric/Hermitian/triangular) vs the original; `\`/`solve`/`solve!`/`ldiv!` for LU/Cholesky/QR/LDLT vs dense `\`/`lu`/`cholesky`/`qr`; rectangular least-squares vs dense `\`; `refactor!` and `lu!`/`cholesky!`/`ldlt!` reuse vs a fresh factorization; singular / non-PD / dimension-mismatch / not-yet-factored error paths. Float32/Float64/ComplexF32/ComplexF64 are all exercised.

## Source changes

None — `src/sparse.jl` was already richly tested; only `test/sparse_tests.jl` was extended.

## Uncovered / defensive notes

- After this change there are **no remaining uncovered coverable lines** in `src/sparse.jl`.
- The complex-Hermitian **LDLT-refactor** coverage runs in a **fresh subprocess**: Apple's libSparse has a process-global defect where a prior complex-Hermitian factorization poisons a later complex-Hermitian LDLT refactor, crashing (SIGSEGV) inside libSparse's own workspace sizing. Isolating that one test in its own process covers our routing fix without crashing the suite (pre-existing pattern, retained).

Full `Pkg.test()` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)