### PR TITLE
Raise coverage of BLAS/LAPACK forwarding spine

### DIFF
--- a/test/linalg_tests.jl
+++ b/test/linalg_tests.jl
@@ -72,6 +72,84 @@ end
     end
 end
 
+@testset "Forwarding spine coverage" begin
+    # --- forward_accelerate argument validation -------------------------------
+    # ILP64 without new_lapack is unsupported and must error up front.
+    @test_throws ArgumentError AppleAccelerate.forward_accelerate(:ilp64; new_lapack = false)
+
+    # --- BLAS.get_config reflects Accelerate forwarding -----------------------
+    cfg = BLAS.get_config()
+    acc_libs = filter(l -> endswith(l.libname, "Accelerate"), cfg.loaded_libs)
+    # Accelerate must be forwarded in BOTH interfaces after load_accelerate().
+    @test any(l -> l.interface === :lp64, acc_libs)
+    @test any(l -> l.interface === :ilp64, acc_libs)
+    @test endswith(BLAS.lbt_find_backing_library("dgemm_", :lp64).libname, "Accelerate")
+    @test endswith(BLAS.lbt_find_backing_library("dgemm_", :ilp64).libname, "Accelerate")
+
+    # --- forwarding is correct, not merely present ----------------------------
+    # Reconcile Accelerate's results against independent references.
+    let n = 32
+        for T in (Float64, Float32, ComplexF64)
+            A = rand(T, n, n) + n * I        # well-conditioned
+            B = rand(T, n, n)
+            x = rand(T, n)
+
+            # gemm: compare against an explicit BLAS.gemm! on the same backend
+            # and a hand-rolled triple loop (independent of the BLAS path).
+            C = A * B
+            Cref = fill(zero(T), n, n)
+            BLAS.gemm!('N', 'N', one(T), A, B, zero(T), Cref)
+            @test C ≈ Cref
+            Chand = [sum(A[i, k] * B[k, j] for k in 1:n) for i in 1:n, j in 1:n]
+            @test C ≈ Chand
+
+            # lu / solve: residual must be tiny.
+            F = lu(A)
+            @test F.L * F.U ≈ A[F.p, :]
+            xs = A \ x
+            @test A * xs ≈ x
+            rtol = T <: Union{Float32,ComplexF32} ? 1e-3 : 1e-9
+            @test norm(A * xs - x) / norm(x) < rtol
+        end
+    end
+
+    # --- get_macos_version returns a consistent VersionNumber (caching) -------
+    v1 = AppleAccelerate.get_macos_version()
+    v2 = AppleAccelerate.get_macos_version()
+    @test v1 isa VersionNumber
+    @test v1 == v2                     # cached: identical across calls
+    @test AppleAccelerate._read_macos_version() isa VersionNumber
+
+    # Exercise the precompile-time fallback branch in get_macos_version where the
+    # cache Ref is still `nothing` and it must read the plist directly.
+    saved_ver = AppleAccelerate._macos_version[]
+    try
+        AppleAccelerate._macos_version[] = nothing
+        vfallback = AppleAccelerate.get_macos_version()   # hits the _read_macos_version() fallback
+        @test vfallback isa VersionNumber
+        @test vfallback == saved_ver
+    finally
+        AppleAccelerate._macos_version[] = saved_ver
+    end
+
+    # --- threading API on the synthetic "too old" path ------------------------
+    # On macOS < 15 the threading toggles must warn and return 1 without touching
+    # the (unavailable) Accelerate threading symbols. We can't downgrade the OS,
+    # but we can spoof the cached version to drive those guarded branches.
+    let saved = AppleAccelerate._macos_version[]
+        try
+            AppleAccelerate._macos_version[] = v"14.0.0"
+            @test AppleAccelerate.get_num_threads() == 1
+            @test AppleAccelerate.set_num_threads(1) == 1
+            @test AppleAccelerate.set_num_threads(8) == 1
+            # Argument validation still fires before the version guard.
+            @test_throws ArgumentError AppleAccelerate.set_num_threads(0)
+        finally
+            AppleAccelerate._macos_version[] = saved
+        end
+    end
+end
+
 linalg_stdlib_test_path = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 
 @testset verbose=false "LinearAlgebra.jl BLAS tests" begin


### PR DESCRIPTION
## Goal

Maximize coverage of the spine functions in `src/AppleAccelerate.jl` — BLAS/LAPACK forwarding (`forward_accelerate`, `load_accelerate`), the threading API (`set_num_threads`/`get_num_threads`), and macOS version detection (`_read_macos_version`/`get_macos_version`) — and reconcile observable behavior against `LinearAlgebra.BLAS` config / OpenBLAS. Tests only; no forwarding behavior changed.

## Coverage of the spine functions (coverable lines)

| Function | Baseline | Final |
|---|---|---|
| `forward_accelerate` | 7/9 | 9/9 |
| `load_accelerate` | 7/9 | 7/9 |
| `_read_macos_version` | 12/15 | 12/15 |
| `get_macos_version` | 4/5 | 5/5 |
| `set_num_threads` | 11/13 | 13/13 |
| `get_num_threads` | 8/11 | 10/11 |
| **TOTAL** | **49/62 = 79.0%** | **56/62 = 90.3%** |

Measured with `--code-coverage=user` running `test/linalg_tests.jl`.

## Additions (all in `test/linalg_tests.jl`, new "Forwarding spine coverage" testset)

- **`forward_accelerate`**: cover the ILP64-without-`new_lapack` `ArgumentError` path.
- **`BLAS.get_config` reconciliation**: assert Accelerate is forwarded in both `:lp64` and `:ilp64`; verify `dgemm_` backs to Accelerate in both interfaces.
- **Forwarding correctness, not just presence**: `Float64`/`Float32`/`ComplexF64` gemm reconciled against `BLAS.gemm!` *and* an independent hand-rolled triple-loop reference; `lu`/`\` residuals checked against tight tolerances.
- **`get_macos_version`**: cover the precompile-time fallback branch by spoofing the cached version `Ref` to `nothing` and restoring it; assert caching consistency (identical `VersionNumber` across calls).
- **Threading guards**: spoof the cached macOS version to `v"14"` to drive the macOS<15 warn-and-return-1 branches of `set_num_threads`/`get_num_threads`, with restore in a `finally`; argument validation still asserted.

## References used for reconciliation

- `BLAS.gemm!` on the same (Accelerate) backend.
- A hand-rolled triple-loop gemm independent of the BLAS path.
- Residual norms for `lu`/solve (`norm(A*x - b)/norm(b)` under type-appropriate tolerance).

## Intentionally unreachable in-process (left uncovered)

These are init-only or platform-guarded and cannot be hit in-process on macOS 26 arm64 without changing forwarding behavior:

- `_read_macos_version` L78 / L83 — plist parse-failure returns (the real system plist parses fine).
- `_read_macos_version` L91 — the 16.x→26.x Tahoe normalization; the function reads a hard-coded system path and exposes no injection point for synthetic input.
- `load_accelerate` L47 — `return` when Accelerate fails to `dlopen` (it always loads here).
- `load_accelerate` L52 — `error` when ILP64 symbols are missing (present on macOS 13.4+).
- `get_num_threads` L159 — error on an unexpected `BLASGetThreading` value (the API never returns an invalid value).

## Test status

Full `Pkg.test()` is GREEN, including the existing LinearAlgebra stdlib BLAS/LAPACK suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)