### PR TITLE
test(bnns): 100% coverage cross-validation for BNNS + NNlib ext

### DIFF
--- a/test/bnns_tests.jl
+++ b/test/bnns_tests.jl
@@ -1,5 +1,6 @@
 using AppleAccelerate
-using AppleAccelerate: BNNSArray, bnns_matmul, bnns_matmul!, bnns_activation, bnns_activation!
+using AppleAccelerate: BNNSArray, bnns_matmul, bnns_matmul!, bnns_activation, bnns_activation!,
+                      bnns_data_type
 using LinearAlgebra
 using Test
 
@@ -27,6 +28,32 @@ using Test
                                                     randn(Float32, 2, 3), randn(Float32, 4, 2))
         @test_throws DimensionMismatch bnns_matmul!(zeros(Float32, 3, 3),
                                                     randn(Float32, 2, 3), randn(Float32, 3, 2))
+
+        # Non-Array (strided/transposed) inputs go through the `Array(A)` copy
+        # path inside bnns_matmul!.
+        let Al = randn(Float32, 4, 3), Bl = randn(Float32, 4, 5)
+            @test bnns_matmul(transpose(Al), Bl) ≈ transpose(Al) * Bl atol = 1f-4 rtol = 1f-4
+            adj = adjoint(randn(Float32, 3, 6))   # 6×3 adjoint wrapper
+            Bk = randn(Float32, 3, 2)
+            @test bnns_matmul(adj, Bk) ≈ adj * Bk atol = 1f-4 rtol = 1f-4
+            @test bnns_matmul(adj, Bk) isa Matrix{Float32}
+        end
+
+        # View / transpose destination exercises the temp-buffer copy-back path
+        # (Cc !== C) in bnns_matmul!.
+        let A = randn(Float32, 4, 3), B = randn(Float32, 3, 5), ref = nothing
+            ref = A * B
+            Cbig = zeros(Float32, 8, 8)
+            Cv = view(Cbig, 1:4, 1:5)
+            @test bnns_matmul!(Cv, A, B) === Cv
+            @test Cv ≈ ref atol = 1f-4 rtol = 1f-4
+            @test all(==(0f0), Cbig[5:8, :])  # untouched region
+
+            sq = randn(Float32, 3, 3)
+            Ct = transpose(zeros(Float32, 3, 3))
+            @test bnns_matmul!(Ct, sq, sq) === Ct
+            @test Ct ≈ sq * sq atol = 1f-4 rtol = 1f-4
+        end
     end
 
     @testset "activation" begin
@@ -53,6 +80,21 @@ using Test
         v = randn(Float32, 100) .- 0.5f0
         @test bnns_activation(:relu, v) ≈ max.(v, 0f0) atol=1f-6
 
+        # In-place aliasing X === Y on a Vector (Yc === Xc, true in-place).
+        let w = randn(Float32, 64) .- 0.5f0, wref = tanh.(copy(w))
+            @test bnns_activation!(:tanh, w, w) === w
+            @test w ≈ wref atol = 1f-5 rtol = 1f-5
+        end
+
+        # Transposed / strided input drives the `vec(Array(X))` copy path.
+        let Xs = (randn(Float32, 5, 7) .- 0.5f0)
+            Xt = transpose(Xs)              # 7×5 lazy transpose
+            @test bnns_activation(:sigmoid, Xt) ≈ (1 ./ (1 .+ exp.(-Xt))) atol = 1f-5 rtol = 1f-5
+            Yt = similar(Array(Xt))
+            @test bnns_activation!(:relu, Yt, Xt) === Yt
+            @test Yt ≈ max.(Array(Xt), 0f0) atol = 1f-6
+        end
+
         @test_throws ArgumentError bnns_activation(:nope, X)
         @test_throws DimensionMismatch bnns_activation!(:relu, zeros(Float32, 2), X)
     end
@@ -63,9 +105,25 @@ using Test
         @test d.parent === A
         @test d.desc.size[1] == 3
         @test d.desc.size[2] == 4
+        # column-major strides reported explicitly: stride[2] == rows.
+        @test d.desc.stride[1] == 1
+        @test d.desc.stride[2] == 3
         v = rand(Float32, 5)
         dv = BNNSArray(v)
         @test dv.desc.size[1] == 5
+        @test dv.desc.stride[1] == 1
+
+        # Int32 element type goes through bnns_data_type(Int32).
+        @test bnns_data_type(Float32) == bnns_data_type(Float32)
+        @test bnns_data_type(Int32) != bnns_data_type(Float32)
+        @test_throws ArgumentError bnns_data_type(Float64)
+        di = BNNSArray(Int32[1 2 3; 4 5 6])
+        @test di.desc.size[1] == 2
+        @test di.desc.size[2] == 3
+        @test di.parent isa Matrix{Int32}
+        dvi = BNNSArray(Int32[1, 2, 3, 4])
+        @test dvi.desc.size[1] == 4
+
         @test_throws ArgumentError BNNSArray(rand(Float32, 2, 2, 2))
         @test_throws ArgumentError BNNSArray(rand(Float64, 2, 2))
     end

--- a/test/nnlib_ext_tests.jl
+++ b/test/nnlib_ext_tests.jl
@@ -26,6 +26,23 @@ using Test
             NNlib.batched_mul!(C3, A, B, 1.0f0, 0.5f0)
             @test C3 ≈ ref .+ 0.5f0 .* base atol=1f-4 rtol=1f-4
         end
+
+        # Unequal batch dims (broadcast batch) must take the @invoke fallback,
+        # not the BNNS fast path (which requires equal size(.,3)).
+        let A = randn(Float32, 3, 4, 5), B = randn(Float32, 4, 2, 1)
+            ref = NNlib.batched_mul(A, B)
+            C = similar(ref)
+            @test NNlib.batched_mul!(C, A, B) === C
+            @test C ≈ ref atol = 1f-4 rtol = 1f-4
+            @test size(C, 3) == 5
+        end
+
+        # Transposed batch slices: BatchedTranspose isn't Array{Float32,3}, so
+        # this dispatches to the generic NNlib method (sanity cross-check).
+        let A = randn(Float32, 4, 3, 2), B = randn(Float32, 4, 5, 2)
+            ref = NNlib.batched_mul(NNlib.batched_transpose(A), B)
+            @test NNlib.batched_mul(NNlib.batched_transpose(A), B) ≈ ref atol = 1f-4 rtol = 1f-4
+        end
     end
 
     @testset "activations" begin
@@ -34,6 +51,11 @@ using Test
         @test AppleAccelerate.bnns_act(sigmoid, X) ≈ sigmoid.(X) atol=1f-5
         @test AppleAccelerate.bnns_act(tanh, X)    ≈ tanh.(X)    atol=1f-5
         @test AppleAccelerate.bnns_act(abs, X)     ≈ abs.(X)     atol=1f-6
+        # σ / tanh_fast / identity alias entries in the _NNLIB_ACT map.
+        @test AppleAccelerate.bnns_act(NNlib.σ, X)         ≈ NNlib.σ.(X)         atol=1f-5
+        @test AppleAccelerate.bnns_act(NNlib.tanh_fast, X) ≈ NNlib.tanh_fast.(X) atol=1f-5
+        @test AppleAccelerate.bnns_act(identity, X)        == X
+        @test AppleAccelerate.bnns_act(identity, X) !== X  # returns a fresh array
         # unsupported activation falls back to broadcasting f
         @test AppleAccelerate.bnns_act(NNlib.softplus, X) ≈ NNlib.softplus.(X) atol=1f-5
     end


### PR DESCRIPTION
## Summary

Strengthens the BNNS test suite to fully cover and numerically cross-validate `src/bnns.jl` and `ext/AppleAccelerateNNlibExt.jl` against plain-Julia / NNlib references.

## Coverage (coverable lines, `--code-coverage=user`)

| File | Baseline | Final |
|------|----------|-------|
| `src/bnns.jl` | 100% (71/71) | 100% (72/72) |
| `ext/AppleAccelerateNNlibExt.jl` | 100% (12/12) | 100% (12/12) |

Both files were already at 100% line coverage at baseline; this PR adds depth — exercising and asserting the documented edge-case paths that were previously only incidentally hit, so the behaviour is locked in against regressions.

## Additions

`test/bnns_tests.jl`:
- `bnns_matmul!` non-`Array` inputs (`transpose`/`adjoint`) through the `Array(A)` copy path, verified against `A*B`.
- View and transpose destination through the temp-buffer copy-back path (`Cc !== C`), including untouched-region check.
- `bnns_activation!` in-place `X===Y` vector aliasing; transposed/strided input `vec(Array(X))` path.
- `BNNSArray` column-major stride reporting; `Int32` descriptor + `bnns_data_type(Int32)`/`(Float32)` paths and the unsupported-type `ArgumentError`.

`test/nnlib_ext_tests.jl`:
- Unequal-batch and batched-transpose `@invoke` fallbacks for `batched_mul!`.
- `σ` / `tanh_fast` / `identity` alias entries in `_NNLIB_ACT`, plus `identity` returning a fresh array.

## Validation

- BNNS core: 79 pass. NNlib extension: 23 pass.
- Full `Pkg.test()` GREEN (Julia 1.12, macOS arm64).

## Uncovered / out of scope

None remaining in the two owned files. The broader BNNS graph API, convolution/pooling/normalization/LSTM/attention layers, quantization, and training remain intentionally at the raw `LibAccelerate` layer (documented in `src/bnns.jl` header) and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)