### PR TITLE
codecov: ignore generated raw layer and gen/ scripts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,14 @@
+# Exclude generated / non-library code so the project coverage % reflects the
+# hand-written idiomatic API:
+#   - src/lib/LibAccelerate.jl is the Clang.jl auto-generated raw ABI layer
+#     (~1000 @ccall wrappers). Only the subset the idiomatic layer calls is
+#     exercised; it's validated by the dlsym-probe + typedef tests and indirectly
+#     through the idiomatic tests, not unit-tested wrapper-by-wrapper.
+#   - gen/ holds the binding-generator scripts, not shipped as library code.
+ignore:
+  - "src/lib/LibAccelerate.jl"
+  - "gen"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Project coverage was dominated by `src/lib/LibAccelerate.jl` — the Clang.jl auto-generated raw ABI layer (~1000 `@ccall` wrappers, of which the idiomatic layer calls only ~28) — pulling the reported number to ~58% even though the hand-written modules are ~100% covered.

This adds a codecov `ignore:` list for the generated bindings and the `gen/` generator scripts, so project coverage reflects the actual idiomatic library surface. The raw layer is still validated by the dlsym-probe + typedef tests and exercised indirectly through the idiomatic tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)