### PR TITLE
docs: correct stale FFT and GEMM performance claims in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/documentation/accelerate), providing:
 
 - **Vectorized array operations** via vecLib (`vv*`) and vDSP (`vDSP_*`) — element-wise math, reductions, compound arithmetic, clipping, interpolation, integration, and more — **2–19× faster** than Base Julia for transcendental functions (`sin`, `cos`, `exp`, `log`)
-- **Dense linear algebra** via BLAS/LAPACK forwarding through [libblastrampoline](https://github.com/JuliaLinearAlgebra/libblastrampoline) — all standard `LinearAlgebra` operations (`lu`, `qr`, `svd`, `cholesky`, `eigen`, etc.) are accelerated transparently — **6–14× faster** GEMM than OpenBLAS on Apple Silicon, **2–4× faster** factorizations and solves
+- **Dense linear algebra** via BLAS/LAPACK forwarding through [libblastrampoline](https://github.com/JuliaLinearAlgebra/libblastrampoline) — all standard `LinearAlgebra` operations (`lu`, `qr`, `svd`, `cholesky`, `eigen`, etc.) are accelerated transparently — **6–13× faster** single-threaded GEMM than OpenBLAS on Apple Silicon (Accelerate offloads to the SME co-processor; OpenBLAS scales across CPU cores), **2–4× faster** factorizations and solves
 - **Sparse linear algebra** via `libSparse` — sparse matrix operations and direct solvers (QR, Cholesky, LDLT) — **faster for Float32 QR** and **Cholesky at N=5000** vs SuiteSparse
-- **Signal Processing** — FFT, DCT, convolution, cross-correlation, biquad filtering, window functions — **on par with FFTW** for complex FFT, **up to 2× faster** for Float32 real FFT
+- **Signal Processing** — FFT, DCT, convolution, cross-correlation, biquad filtering, window functions — FFTW is generally faster (roughly 2–13× across complex 1D, real, and 2D FFT), with vDSP reaching parity only for large Float32 1D sizes; vDSP's FFT is still useful to avoid an FFTW dependency or when Accelerate is already loaded
 
 ## Installation
 


### PR DESCRIPTION
## Summary

The README's performance claims for FFT were factually wrong and the GEMM claim lacked a threading caveat. This PR aligns both bullets with the freshly-measured M2 Max numbers already in `docs/src/benchmarks.md` (unchanged here).

- **Signal Processing bullet**: previously claimed vDSP was "on par with FFTW" for complex FFT and "up to 2× faster" for Float32 real FFT. The current benchmarks show FFTW leads by roughly 2–13× across complex 1D, real, and 2D FFT, with vDSP only reaching parity for large Float32 1D sizes. Reworded to match benchmarks.md, noting vDSP's FFT is still useful to avoid an FFTW dependency or when Accelerate is already loaded.
- **Dense LA bullet**: the "6–14× faster GEMM than OpenBLAS" figure is a single-threaded comparison. Added a "single-threaded" qualifier plus a brief note that Accelerate offloads to the SME co-processor while OpenBLAS scales across CPU cores, and updated the multiple to ~6–13× to match benchmarks.md.

No changes to `docs/src/benchmarks.md`. Markdown list structure and links are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)