### PR TITLE
Harden FFI/GC safety: GC.@preserve owning objects across ccalls

### DIFF
--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -132,7 +132,7 @@ function set_num_threads(n::Integer)
     elseif n > 1
         retval = ccall((:BLASSetThreading, libacc), Cint, (Cint,), BLAS_THREADING_MULTI_THREADED)
     end
-    @assert retval == 0 "AppleAccelerate: Call to BLASSetThreading failed"
+    retval == 0 || error("AppleAccelerate: Call to BLASSetThreading failed")
     return get_num_threads()
 end
 

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -70,7 +70,9 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             # to keep reads in-bounds for an oversized `result` buffer. Total
             # padded length = rsize + 2*ksize - 1 (front pad ksize-1).
             xpadded::Vector{$T} = [zeros($T, ksize-1); X; zeros($T, rsize + ksize - xsize)]
-            LibAccelerate.$(Symbol(string("vDSP_conv", suff)))(xpadded,1,pointer(K, ksize),-1,result,1,rsize,ksize)
+            # `pointer(K, ksize)` is a bare pointer into K's buffer; root K across
+            # the ccall so it cannot be collected mid-call.
+            GC.@preserve K LibAccelerate.$(Symbol(string("vDSP_conv", suff)))(xpadded,1,pointer(K, ksize),-1,result,1,rsize,ksize)
             return result
         end
     end
@@ -118,7 +120,8 @@ for (T, suff) in ((Float64, "D"), (Float32, ""))
             # from rsize so an oversized `result` buffer stays in-bounds. Total
             # padded length = rsize + 2*ysize - 1 (front pad ysize-1).
             xpadded::Vector{$T} = [zeros($T, ysize-1); X; zeros($T, rsize + ysize - xsize)]
-            LibAccelerate.$(Symbol(string("vDSP_conv", suff)))(xpadded,1,Y,1,result,1,rsize,ysize)
+            # Y backs the kernel argument; root it across the ccall.
+            GC.@preserve Y LibAccelerate.$(Symbol(string("vDSP_conv", suff)))(xpadded,1,Y,1,result,1,rsize,ysize)
             return result
         end
     end

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -940,7 +940,9 @@ function Base.transpose(M::AASparseMatrix)
         throw(ArgumentError("cannot transpose an already-adjointed AASparseMatrix " *
             "(libSparse cannot represent the resulting `conj(A)` view; " *
             "apply `conj` to the underlying data instead)"))
-    AASparseMatrix(SparseGetTranspose(M.matrix), M._colptr, M._rowval, M._nzval)
+    # M.matrix carries raw pointers into M's CSC buffers; keep M alive for the call.
+    t = GC.@preserve M SparseGetTranspose(M.matrix)
+    AASparseMatrix(t, M._colptr, M._rowval, M._nzval)
 end
 
 # Real: same as transpose. Complex: flip ct (and toggle t); CSC data shared.
@@ -952,8 +954,8 @@ function Base.adjoint(M::AASparseMatrix{T}) where T<:Complex
         throw(ArgumentError("cannot adjoint an already-transposed AASparseMatrix " *
             "(libSparse cannot represent the resulting `conj(A)` view; " *
             "apply `conj` to the underlying data instead)"))
-    AASparseMatrix(SparseGetConjugateTranspose(M.matrix),
-                   M._colptr, M._rowval, M._nzval)
+    ct = GC.@preserve M SparseGetConjugateTranspose(M.matrix)
+    AASparseMatrix(ct, M._colptr, M._rowval, M._nzval)
 end
 
 function Base.:(*)(A::AASparseMatrix{T}, x::StridedVecOrMat{T}) where T<:vTypes
@@ -961,7 +963,9 @@ function Base.:(*)(A::AASparseMatrix{T}, x::StridedVecOrMat{T}) where T<:vTypes
         "Matrix and right-hand side size mismatch: got "
         * "$(size(A)[2]) and $(size(x, 1))"))
     y = Array{T}(undef, size(A)[1], size(x)[2:end]...)
-    SparseMultiply(A.matrix, x, y)
+    # A.matrix is a C value struct holding raw pointers into A's CSC buffers,
+    # which nothing else roots across the ccall; keep A alive for the call.
+    GC.@preserve A SparseMultiply(A.matrix, x, y)
     return y
 end
 
@@ -971,7 +975,7 @@ function Base.:(*)(alpha::T, A::AASparseMatrix{T},
         "Matrix and right-hand side size mismatch: got "
         * "$(size(A)[2]) and $(size(x, 1))"))
     y = Array{T}(undef, size(A)[1], size(x)[2:end]...)
-    SparseMultiply(alpha, A.matrix, x, y)
+    GC.@preserve A SparseMultiply(alpha, A.matrix, x, y)
     return y
 end
 
@@ -984,7 +988,7 @@ function muladd!(A::AASparseMatrix{T}, x::StridedVecOrMat{T},
         size(x)[2:end] == size(y)[2:end]) || throw(DimensionMismatch(
         "Dimension mismatch in y += A*x: A is $(size(A)), "
         * "x is $(size(x)), y is $(size(y))"))
-    SparseMultiplyAdd(A.matrix, x, y)
+    GC.@preserve A SparseMultiplyAdd(A.matrix, x, y)
 end
 
 """
@@ -996,7 +1000,7 @@ function muladd!(alpha::T, A::AASparseMatrix{T},
         size(x)[2:end] == size(y)[2:end]) || throw(DimensionMismatch(
         "Dimension mismatch in y += alpha*A*x: A is $(size(A)), "
         * "x is $(size(x)), y is $(size(y))"))
-    SparseMultiplyAdd(alpha, A.matrix, x, y)
+    GC.@preserve A SparseMultiplyAdd(alpha, A.matrix, x, y)
 end
 
 # ============================================================
@@ -1155,7 +1159,9 @@ function factor!(aa_fact::AAFactorization{T},
                    (nrow == ncol && lu_ok)        ? SparseFactorizationLU :
                                                     SparseFactorizationQR
         end
-        fact = SparseFactor(kind, aa_fact.matrixObj.matrix)
+        # matrixObj.matrix holds raw pointers into the CSC buffers; keep the
+        # owning wrapper alive across the factorization call.
+        fact = GC.@preserve aa_fact SparseFactor(kind, aa_fact.matrixObj.matrix)
         if fact.status == SparseStatusOk
             aa_fact._factorization = fact
         else


### PR DESCRIPTION
## Summary

Safety-hardening for FFI/GC correctness. Several `ccall` sites pass either a bare `pointer(...)` or a C value struct (`SparseMatrix{T}` / `SparseMatrixStructure`) that holds raw `Ptr`s into a Julia object's backing buffers, without keeping the owning object rooted for the duration of the call. If GC runs during the C call and the owner is otherwise dead, the buffers can be collected out from under libSparse/vDSP. This PR wraps those sites in `GC.@preserve <owner>`.

`SparseMatrix{T}` and `SparseMatrixStructure` have **no `cconvert`** rooting them — they are passed by value with raw pointers — so the owning `AASparseMatrix` (which holds `_colptr`/`_rowval`/`_nzval`) must be preserved explicitly.

## Changes

**src/sparse.jl (A4)** — wrapped by-value `.matrix` ccall sites:
- `Base.:(*)(A, x)` → `GC.@preserve A SparseMultiply(...)`
- `Base.:(*)(alpha, A, x)` → `GC.@preserve A SparseMultiply(...)`
- `muladd!(A, x, y)` → `GC.@preserve A SparseMultiplyAdd(...)`
- `muladd!(alpha, A, x, y)` → `GC.@preserve A SparseMultiplyAdd(...)`
- `transpose(M)` → `GC.@preserve M SparseGetTranspose(M.matrix)`
- `adjoint(M)` → `GC.@preserve M SparseGetConjugateTranspose(M.matrix)`
- `factor!` → `GC.@preserve aa_fact SparseFactor(kind, aa_fact.matrixObj.matrix)`

(`refactor!` / `_sparse_refactor!` already used `GC.@preserve`; the `SparseSolve` paths pass the opaque factorization + auto-rooted dense arrays, so they need no change.)

**src/dsp.jl (A5)** — `conv!` passed `pointer(K, ksize)` as a bare pointer → wrapped in `GC.@preserve K`. `xcorr!`'s call wrapped in `GC.@preserve Y`. (Edits confined to `conv!`/`xcorr!`; FFT-setup code untouched.)

**src/AppleAccelerate.jl (A8)** — `set_num_threads` replaced `@assert retval == 0 ...` (elided under `-O3` / `--check-bounds=no`) with `retval == 0 || error("AppleAccelerate: Call to BLASSetThreading failed")`.

Behavior for valid calls is unchanged; no new allocations.

## Tests

`julia --project -e 'using Pkg; Pkg.test()'` passes, including Sparse Linear Algebra (507), Signal Processing (201), and Dense Linear Algebra (3115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)