### PR TITLE
Add mixed-radix (non-power-of-2) 1D complex FFT support

### DIFF
--- a/docs/src/fft.md
+++ b/docs/src/fft.md
@@ -8,10 +8,10 @@ using AppleAccelerate
 
 ## FFT
 
-The FFT API wraps Apple's [vDSP FFT functions](https://developer.apple.com/documentation/accelerate/fast_fourier_transforms) and follows the same naming conventions as [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl). Both 1D vectors and 2D matrices are supported with `ComplexF64` and `ComplexF32` inputs. All dimensions must be powers of 2.
+The FFT API wraps Apple's [vDSP FFT functions](https://developer.apple.com/documentation/accelerate/fast_fourier_transforms) and follows the same naming conventions as [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl). Both 1D vectors and 2D matrices are supported with `ComplexF64` and `ComplexF32` inputs. A **1D complex** `fft`/`ifft`/`bfft` (called without an explicit `plan_fft` setup) accepts lengths of the form `f * 2^k` with `f ∈ {1, 3, 5, 15}` — powers of two use vDSP's fast FFT path, while other supported lengths transparently use Apple's mixed-radix DFT (see [`is_supported_fft_length`](@ref AppleAccelerate.is_supported_fft_length)). **2D transforms and the real FFT (`rfft`/`brfft`) remain power-of-2 only.** Unsupported 1D lengths throw an `ArgumentError`.
 
 !!! note "Choosing between AppleAccelerate and FFTW"
-    AppleAccelerate's FFT is a direct vDSP binding: all dimensions must be powers of 2, only 1-D vectors and 2-D matrices are supported, and it is reached exclusively through the `AppleAccelerate.` prefix. It does **not** plug into the AbstractFFTs.jl interface — loading AppleAccelerate never changes what `fft`/`plan_fft` do in your session, and will never override FFTW.jl.
+    AppleAccelerate's FFT is a direct vDSP binding: 1-D complex transforms support `f * 2^k` lengths (`f ∈ {1, 3, 5, 15}`), while 2-D transforms and the real FFT are power-of-2 only. Only 1-D vectors and 2-D matrices are supported, and it is reached exclusively through the `AppleAccelerate.` prefix. It does **not** plug into the AbstractFFTs.jl interface — loading AppleAccelerate never changes what `fft`/`plan_fft` do in your session, and will never override FFTW.jl.
 
     For general sizes, 3-D and higher arrays, dimension-selective (`region`) transforms, or the standard Julia FFT interface, use [FFTW.jl](https://github.com/JuliaMath/FFTW.jl). vDSP is mainly competitive at small transform sizes; FFTW is typically faster at larger ones.
 
@@ -66,6 +66,7 @@ AppleAccelerate.bfft
 AppleAccelerate.fft!
 AppleAccelerate.ifft!
 AppleAccelerate.bfft!
+AppleAccelerate.is_supported_fft_length
 ```
 
 ## Real FFT

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,7 +17,7 @@ Pkg.add("AppleAccelerate")
 |---------|---------|---------|
 | Dense Linear Algebra | [BLAS](https://developer.apple.com/documentation/accelerate/blas) / [LAPACK](https://developer.apple.com/documentation/accelerate/solving-systems-of-linear-equations-with-lapack) | Automatic forwarding via LBT — `lu`, `qr`, `svd`, `mul!`, etc. |
 | Array Operations | [vDSP](https://developer.apple.com/documentation/accelerate/vdsp) / [vecLib](https://developer.apple.com/documentation/accelerate/veclib) | Element-wise math (`exp`, `sin`, `log`), reductions, vector arithmetic |
-| FFT & Transforms | [vDSP FFT](https://developer.apple.com/documentation/accelerate/fast_fourier_transforms) | Complex/real FFT (1D/2D, power-of-2), DFT, DCT — direct vDSP bindings under the `AppleAccelerate.` namespace |
+| FFT & Transforms | [vDSP FFT](https://developer.apple.com/documentation/accelerate/fast_fourier_transforms) | Complex FFT (1D `f*2^k` with `f ∈ {1,3,5,15}`, 2D power-of-2), real FFT (power-of-2), DFT, DCT — direct vDSP bindings under the `AppleAccelerate.` namespace |
 | Filtering & Spectral | [vDSP](https://developer.apple.com/documentation/accelerate/vdsp) | Convolution, biquad IIR, spectral analysis, window functions |
 | Sparse Linear Algebra | [Sparse Solvers](https://developer.apple.com/documentation/accelerate/sparse_solvers) | SpMV, direct solvers (QR, Cholesky, LDLT), factorization reuse (`refactor!`) |
 | Neural Network Primitives | [BNNS](https://developer.apple.com/documentation/accelerate/bnns) | `Float32` matmul and activations — see [BNNS](@ref "Neural Network Primitives (BNNS)") |
@@ -34,7 +34,7 @@ elsewhere in your session does. See [Architecture](@ref architecture).
 
 !!! warning "Key Limitations"
     - **macOS only** — this package uses Apple's Accelerate framework, which is not available on Linux or Windows.
-    - **FFT requires power-of-2 sizes** — use FFTW.jl for arbitrary sizes. DFT supports `f * 2^n` where `f ∈ {1, 3, 5, 15}`.
+    - **FFT size limits** — 1D complex `fft`/`ifft`/`bfft` support lengths `f * 2^k` with `f ∈ {1, 3, 5, 15}`; 2D transforms and the real FFT (`rfft`/`brfft`) are power-of-2 only. DFT also supports `f * 2^n` where `f ∈ {1, 3, 5, 15}`. Use FFTW.jl for other sizes or N-D transforms.
     - **Float32/Float64 only** — no support for integer or extended-precision types.
 
 ## Quick Start

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -1095,6 +1095,13 @@ end
 
 # --- Public API: fft (forward FFT) ---
 
+# Mixed-radix 1D complex transform via the vDSP DFT (non-power-of-2). `direction` is
+# DFT_FORWARD or DFT_INVERSE. Result is unnormalized (matching bfft/dft conventions).
+function _fft1d_dft(x::Vector{Complex{T}}, direction::Int) where {T<:Union{Float32,Float64}}
+    setup = plan_dft(length(x), direction, T)  # DFTSetup registers its own finalizer
+    return dft(x, setup)
+end
+
 """
     fft(x::VecOrMat{Complex{T}}, [setup::FFTSetup{T}])
 
@@ -1110,13 +1117,6 @@ automatically.
 Wraps [`vDSP_fft_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft_zop) (1D) /
 [`vDSP_fft2d_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft2d_zop) (2D).
 """
-# Mixed-radix 1D complex transform via the vDSP DFT (non-power-of-2). `direction` is
-# DFT_FORWARD or DFT_INVERSE. Result is unnormalized (matching bfft/dft conventions).
-function _fft1d_dft(x::Vector{Complex{T}}, direction::Int) where {T<:Union{Float32,Float64}}
-    setup = plan_dft(length(x), direction, T)  # DFTSetup registers its own finalizer
-    return dft(x, setup)
-end
-
 fft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d(x, setup, FFT_FORWARD)
 fft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d(x, setup, FFT_FORWARD)
 function fft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}}
@@ -1134,6 +1134,11 @@ fft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = fft(x, plan_fft(x
 
 Compute the unnormalized inverse (backward) FFT of `x` via Apple vDSP.
 The result is *not* divided by `length(x)`; use [`ifft`](@ref) for the normalized version.
+
+For a 1D vector with no explicit `setup`, non-power-of-2 lengths of the form
+`f * 2^k` with `f ∈ {1, 3, 5, 15}` are also supported (via Apple's mixed-radix DFT);
+an unsupported length throws an `ArgumentError`. With an explicit `setup::FFTSetup`,
+or for 2D inputs, all dimensions must be powers of 2.
 Wraps [`vDSP_fft_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft_zop) (1D) /
 [`vDSP_fft2d_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft2d_zop) (2D).
 """
@@ -1154,6 +1159,11 @@ bfft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft(x, plan_fft
 
 Compute the normalized inverse FFT of `x` via Apple vDSP.
 Equivalent to `bfft(x) / length(x)`. Satisfies `ifft(fft(x)) ≈ x`.
+
+For a 1D vector with no explicit `setup`, non-power-of-2 lengths of the form
+`f * 2^k` with `f ∈ {1, 3, 5, 15}` are also supported (via Apple's mixed-radix DFT);
+an unsupported length throws an `ArgumentError`. With an explicit `setup::FFTSetup`,
+or for 2D inputs, all dimensions must be powers of 2.
 Wraps [`vDSP_fft_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft_zop) (1D) /
 [`vDSP_fft2d_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft2d_zop) (2D).
 """

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -977,6 +977,34 @@ function destroy_fftsetup(setup::FFTSetup{Float32})
     LibAccelerate.vDSP_destroy_fftsetup(setup.plan)
 end
 
+# --- Mixed-radix length support (for non-power-of-2 1D complex FFT) ---
+#
+# Apple's vDSP DFT (vDSP_DFT_zop_CreateSetup) supports lengths of the form
+# `f * 2^n` where `f ∈ {1, 3, 5, 15}`. `fft`/`ifft`/`bfft` on a 1D vector with no
+# explicit `FFTSetup` transparently route to this mixed-radix DFT path when the
+# length is not a power of two but is a supported `f * 2^n`; power-of-2 lengths
+# keep using the (faster, in-place-capable) `vDSP_fft_*` path unchanged.
+
+# Return the odd cofactor `f` of `n` (i.e. `n` with all factors of 2 removed).
+_odd_cofactor(n::Integer) = n >> trailing_zeros(n)
+
+"""
+    is_supported_fft_length(n::Integer) -> Bool
+
+Return `true` if a 1D complex FFT of length `n` is supported by Apple vDSP via the
+idiomatic `fft`/`ifft`/`bfft` API. Supported lengths are `f * 2^k` with
+`f ∈ {1, 3, 5, 15}` (this includes all powers of two).
+"""
+is_supported_fft_length(n::Integer) = n >= 1 && _odd_cofactor(n) in (1, 3, 5, 15)
+
+# Throw an informative error for an unsupported 1D FFT length.
+@noinline function _unsupported_fft_length(n::Integer)
+    throw(ArgumentError(string(
+        "unsupported FFT length $n: AppleAccelerate only supports 1D complex FFT ",
+        "lengths of the form f*2^k with f ∈ {1, 3, 5, 15}. ",
+        "For arbitrary (e.g. prime) lengths, use FFTW.jl instead.")))
+end
+
 # --- Internal 1D FFT (direction-based) ---
 
 function _fft1d(r::Vector{ComplexF64}, setup::FFTSetup{Float64}, direction::Int)
@@ -1071,14 +1099,32 @@ end
     fft(x::VecOrMat{Complex{T}}, [setup::FFTSetup{T}])
 
 Compute the forward FFT of `x` via Apple vDSP. Supports 1D vectors and 2D matrices
-with `ComplexF32` or `ComplexF64` elements. All dimensions must be powers of 2.
-If `setup` is omitted, a temporary plan is created automatically.
+with `ComplexF32` or `ComplexF64` elements.
+
+For a 1D vector with no explicit `setup`, non-power-of-2 lengths of the form
+`f * 2^k` with `f ∈ {1, 3, 5, 15}` are also supported and transparently use Apple's
+mixed-radix DFT (see [`is_supported_fft_length`](@ref)); an unsupported length throws
+an `ArgumentError`. When a `setup::FFTSetup` is supplied, or for 2D inputs, all
+dimensions must be powers of 2. If `setup` is omitted, a temporary plan is created
+automatically.
 Wraps [`vDSP_fft_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft_zop) (1D) /
 [`vDSP_fft2d_zop`](https://developer.apple.com/documentation/accelerate/vdsp_fft2d_zop) (2D).
 """
+# Mixed-radix 1D complex transform via the vDSP DFT (non-power-of-2). `direction` is
+# DFT_FORWARD or DFT_INVERSE. Result is unnormalized (matching bfft/dft conventions).
+function _fft1d_dft(x::Vector{Complex{T}}, direction::Int) where {T<:Union{Float32,Float64}}
+    setup = plan_dft(length(x), direction, T)  # DFTSetup registers its own finalizer
+    return dft(x, setup)
+end
+
 fft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d(x, setup, FFT_FORWARD)
 fft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d(x, setup, FFT_FORWARD)
-fft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = fft(x, plan_fft(x))
+function fft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}}
+    n = length(x)
+    ispow2(n) && return fft(x, plan_fft(x))
+    is_supported_fft_length(n) || _unsupported_fft_length(n)
+    return _fft1d_dft(x, DFT_FORWARD)
+end
 fft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = fft(x, plan_fft(x))
 
 # --- Public API: bfft (backward/unnormalized inverse FFT) ---
@@ -1093,7 +1139,12 @@ Wraps [`vDSP_fft_zop`](https://developer.apple.com/documentation/accelerate/vdsp
 """
 bfft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft1d(x, setup, FFT_INVERSE)
 bfft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = _fft2d(x, setup, FFT_INVERSE)
-bfft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft(x, plan_fft(x))
+function bfft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}}
+    n = length(x)
+    ispow2(n) && return bfft(x, plan_fft(x))
+    is_supported_fft_length(n) || _unsupported_fft_length(n)
+    return _fft1d_dft(x, DFT_INVERSE)
+end
 bfft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft(x, plan_fft(x))
 
 # --- Public API: ifft (normalized inverse FFT) ---
@@ -1108,7 +1159,8 @@ Wraps [`vDSP_fft_zop`](https://developer.apple.com/documentation/accelerate/vdsp
 """
 ifft(x::Vector{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = bfft(x, setup) ./ length(x)
 ifft(x::Matrix{Complex{T}}, setup::FFTSetup{T}) where {T<:Union{Float32,Float64}} = bfft(x, setup) ./ length(x)
-ifft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft(x, plan_fft(x))
+# No-setup 1D routes through bfft, which handles both power-of-2 and mixed-radix lengths.
+ifft(x::Vector{Complex{T}}) where {T<:Union{Float32,Float64}} = bfft(x) ./ length(x)
 ifft(x::Matrix{Complex{T}}) where {T<:Union{Float32,Float64}} = ifft(x, plan_fft(x))
 
 # --- Internal in-place 1D complex FFT ---

--- a/test/dsp_tests.jl
+++ b/test/dsp_tests.jl
@@ -34,6 +34,44 @@ end
     end
 end
 
+@testset "fft non-power-of-2 (mixed-radix)" begin
+    # Supported non-power-of-2 lengths: f * 2^k with f ∈ {3, 5, 15}.
+    supported = (3 * 2^4, 3 * 2^5, 5 * 2^4, 5 * 2^5, 15 * 2^3, 15 * 2^4)  # 48,96,80,160,120,240
+
+    @testset "ComplexF64 n=$n" for n in supported
+        r = randn(ComplexF64, n)
+        ref = FFTW.fft(r)
+        @test AppleAccelerate.fft(r) ≈ ref
+        # inverse round-trip and match to FFTW's inverse
+        @test AppleAccelerate.ifft(AppleAccelerate.fft(r)) ≈ r
+        @test AppleAccelerate.ifft(ref) ≈ FFTW.ifft(ref)
+        # unnormalized backward transform
+        @test AppleAccelerate.bfft(r) ≈ FFTW.bfft(r)
+    end
+
+    @testset "ComplexF32 n=$n" for n in supported
+        r = randn(ComplexF32, n)
+        ref = FFTW.fft(r)
+        @test AppleAccelerate.fft(r) ≈ ref rtol=sqrt(eps(Float32))
+        @test AppleAccelerate.ifft(AppleAccelerate.fft(r)) ≈ r rtol=sqrt(eps(Float32))
+        @test AppleAccelerate.bfft(r) ≈ FFTW.bfft(r) rtol=sqrt(eps(Float32))
+    end
+
+    # Power-of-2 fast path is unchanged and still routes through fft().
+    @test AppleAccelerate.is_supported_fft_length(1024)
+    @test AppleAccelerate.is_supported_fft_length(48)
+    @test !AppleAccelerate.is_supported_fft_length(7)
+    @test !AppleAccelerate.is_supported_fft_length(11)
+
+    # Unsupported (prime / non-f*2^k) lengths must throw a clear ArgumentError.
+    for n in (7, 11, 13, 63)  # 63 = 7*9, odd cofactor 63 ∉ {1,3,5,15}
+        @test_throws ArgumentError AppleAccelerate.fft(randn(ComplexF64, n))
+        @test_throws ArgumentError AppleAccelerate.fft(randn(ComplexF32, n))
+        @test_throws ArgumentError AppleAccelerate.ifft(randn(ComplexF64, n))
+        @test_throws ArgumentError AppleAccelerate.bfft(randn(ComplexF64, n))
+    end
+end
+
 @testset "fft known values" begin
     # DFT of unit impulse is all ones
     @test AppleAccelerate.fft(ComplexF64[1, 0, 0, 0]) ≈ ComplexF64[1, 1, 1, 1]


### PR DESCRIPTION
## Summary

Enables idiomatic 1D complex FFTs for **non-power-of-2** lengths of the form `f·2ᵏ` with `f ∈ {1, 3, 5, 15}`, matching what Apple's mixed-radix DFT supports.

Previously, `fft`/`ifft`/`bfft` on a 1D vector (with no explicit `FFTSetup`) required a power-of-2 length because they went through `vDSP_create_fftsetup` + `vDSP_fft_zop*`. This PR extends the no-setup 1D vector methods to transparently route to Apple's mixed-radix DFT (`vDSP_DFT_zop_CreateSetup`, the same family already backing `dft`/`idft`) when the length is not a power of two but is supported.

## API added / changed

- `fft(x::Vector{Complex{T}})`, `bfft(...)`, `ifft(...)` — no-setup 1D methods now accept supported `f·2ᵏ` lengths in addition to powers of two. Behavior for power-of-2 inputs is byte-for-byte unchanged (still uses the faster `vDSP_fft_*` path).
- `is_supported_fft_length(n)::Bool` — new predicate: `true` iff `n = f·2ᵏ` with `f ∈ {1,3,5,15}`.
- Unsupported lengths (e.g. primes 7/11/13, or 63=7·9) throw a clear `ArgumentError` pointing users to FFTW.jl.

Unchanged: the explicit-`FFTSetup` methods, all 2D methods, `fft!`/`bfft!`/`ifft!`, and the existing `dft`/`idft` API. The existing `DFTSetup` object (whose constructor already registers a finalizer) is reused, so no setup leaks are introduced.

## Validation

- Compared to FFTW for forward, inverse, and backward transforms across `f·2ᵏ` sizes **48, 96, 80, 160, 120, 240** (i.e. 3·2⁴, 3·2⁵, 5·2⁴, 5·2⁵, 15·2³, 15·2⁴), in both **ComplexF64** and **ComplexF32**, within tight tolerances.
- Asserted `ArgumentError` for unsupported sizes (7, 11, 13, 63).
- Full suite green: `julia --project -e 'using Pkg; Pkg.test()'` passes; Signal Processing testset at 263 tests.

Edits are confined to the FFT/DFT region of `src/dsp.jl` to avoid conflicts with the concurrent `conv!`/`xcorr!` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)