### PR TITLE
Guard against out-of-bounds writes in mutating array ops

### DIFF
--- a/docs/src/array.md
+++ b/docs/src/array.md
@@ -507,6 +507,9 @@ Every function in this family has an allocating variant and a mutating variant
 bit width (`8`, `16`, `32`), so `vfix32` truncates to `Int32`, `vfltu16` converts
 `UInt16` to float, and so on. Both `Float32` and `Float64` are supported.
 
+For the mutating `f!(C, A)` forms, `C` must satisfy `length(C) ≥ length(A)`;
+otherwise a `DimensionMismatch` is thrown before any elements are written.
+
 The two directions differ in how the output type is chosen. For **float → int** the
 integer type is fixed by the function name, so the allocating form is `f(A)`. For
 **int → float** the float width is ambiguous, so the allocating form takes it

--- a/src/array.jl
+++ b/src/array.jl
@@ -966,6 +966,8 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vclip!(result::Vector{$T}, X::Vector{$T}, low::$T, high::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vclip", suff)))(X,1,Ref(low),Ref(high),result,1,length(X))
             return result
         end
@@ -974,6 +976,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vclip!(result, X, low, high)
         end
         function viclip!(result::Vector{$T}, X::Vector{$T}, low::$T, high::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_viclip", suff)))(X,1,Ref(low),Ref(high),result,1,length(X))
             return result
         end
@@ -982,6 +986,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             viclip!(result, X, low, high)
         end
         function vthr!(result::Vector{$T}, X::Vector{$T}, threshold::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vthr", suff)))(X,1,Ref(threshold),result,1,length(X))
             return result
         end
@@ -990,6 +996,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vthr!(result, X, threshold)
         end
         function vthres!(result::Vector{$T}, X::Vector{$T}, threshold::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vthres", suff)))(X,1,Ref(threshold),result,1,length(X))
             return result
         end
@@ -1135,21 +1143,33 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vtrapz!(result, X, step)
         end
         function vswsum!(result::Vector{$T}, X::Vector{$T}, window::Integer)
+            (1 <= window <= length(X)) ||
+                throw(ArgumentError("window ($window) must satisfy 1 <= window <= length(X) ($(length(X)))"))
             n_out = length(X) - window + 1
+            length(result) >= n_out ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) - window + 1 ($n_out)"))
             LibAccelerate.$(Symbol(string("vDSP_vswsum", suff)))(X,1,result,1,n_out,window)
             return result
         end
         function vswsum(X::Vector{$T}, window::Integer)
+            (1 <= window <= length(X)) ||
+                throw(ArgumentError("window ($window) must satisfy 1 <= window <= length(X) ($(length(X)))"))
             n_out = length(X) - window + 1
             result = Vector{$T}(undef, n_out)
             vswsum!(result, X, window)
         end
         function vswmax!(result::Vector{$T}, X::Vector{$T}, window::Integer)
+            (1 <= window <= length(X)) ||
+                throw(ArgumentError("window ($window) must satisfy 1 <= window <= length(X) ($(length(X)))"))
             n_out = length(X) - window + 1
+            length(result) >= n_out ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) - window + 1 ($n_out)"))
             LibAccelerate.$(Symbol(string("vDSP_vswmax", suff)))(X,1,result,1,n_out,window)
             return result
         end
         function vswmax(X::Vector{$T}, window::Integer)
+            (1 <= window <= length(X)) ||
+                throw(ArgumentError("window ($window) must satisfy 1 <= window <= length(X) ($(length(X)))"))
             n_out = length(X) - window + 1
             result = Vector{$T}(undef, n_out)
             vswmax!(result, X, window)
@@ -1180,6 +1200,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vintb!(result, A, B, t)
         end
         function vlint!(result::Vector{$T}, table::Vector{$T}, indices::Vector{$T})
+            length(result) >= length(indices) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(indices) ($(length(indices)))"))
             LibAccelerate.$(Symbol(string("vDSP_vlint", suff)))(table,indices,1,result,1,length(indices),length(table))
             return result
         end
@@ -1188,6 +1210,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vlint!(result, table, indices)
         end
         function vqint!(result::Vector{$T}, table::Vector{$T}, indices::Vector{$T})
+            length(result) >= length(indices) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(indices) ($(length(indices)))"))
             LibAccelerate.$(Symbol(string("vDSP_vqint", suff)))(table,indices,1,result,1,length(indices),length(table))
             return result
         end
@@ -1338,6 +1362,13 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vgathr!(C::Vector{$T}, A::Vector{$T}, B::Vector{UInt})
+            length(C) >= length(B) ||
+                throw(DimensionMismatch("C length ($(length(C))) must be at least length(B) ($(length(B)))"))
+            n = length(A)
+            @inbounds for i in eachindex(B)
+                (1 <= B[i] <= n) ||
+                    throw(BoundsError(A, Int(B[i])))
+            end
             LibAccelerate.$(Symbol(string("vDSP_vgathr", suff)))(A,B,1,C,1,length(B))
             return C
         end
@@ -1346,6 +1377,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vgathr!(C, A, B)
         end
         function vindex!(C::Vector{$T}, A::Vector{$T}, B::Vector{$T})
+            length(C) >= length(B) ||
+                throw(DimensionMismatch("C length ($(length(C))) must be at least length(B) ($(length(B)))"))
             LibAccelerate.$(Symbol(string("vDSP_vindex", suff)))(A,B,1,C,1,length(B))
             return C
         end
@@ -1356,7 +1389,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
     end
 end
 
-@doc "Gather elements by index: `C[i] = A[B[i]]` where B contains 1-based UInt indices. Wraps [`vDSP_vgathr`](https://developer.apple.com/documentation/accelerate/vdsp_vgathr)." vgathr
+@doc "Gather elements by index: `C[i] = A[B[i]]` where B contains 1-based UInt indices in `1:length(A)` (a `BoundsError` is thrown otherwise). Wraps [`vDSP_vgathr`](https://developer.apple.com/documentation/accelerate/vdsp_vgathr)." vgathr
 @doc "Index with float indices: `C[i] = A[trunc(B[i])]` where B contains 0-based float indices. Wraps [`vDSP_vindex`](https://developer.apple.com/documentation/accelerate/vdsp_vindex)." vindex
 
 # --- Generation ---
@@ -1371,6 +1404,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vgen!(C, a, b)
         end
         function vgenp!(C::Vector{$T}, A::Vector{$T}, B::Vector{$T}, n::Integer)
+            length(C) >= n ||
+                throw(DimensionMismatch("C length ($(length(C))) must be at least n ($n)"))
             LibAccelerate.$(Symbol(string("vDSP_vgenp", suff)))(A,1,B,1,C,1,n,length(A))
             return C
         end
@@ -1388,6 +1423,8 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vclipc!(result::Vector{$T}, X::Vector{$T}, low::$T, high::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             nlow = Ref{UInt64}(0)
             nhigh = Ref{UInt64}(0)
             LibAccelerate.$(Symbol(string("vDSP_vclipc", suff)))(X,1,Ref(low),Ref(high),result,1,length(X),nlow,nhigh)
@@ -1398,6 +1435,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vclipc!(result, X, low, high)
         end
         function vlim!(result::Vector{$T}, A::Vector{$T}, b::$T, c::$T)
+            length(result) >= length(A) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(A) ($(length(A)))"))
             LibAccelerate.$(Symbol(string("vDSP_vlim", suff)))(A,1,Ref(b),Ref(c),result,1,length(A))
             return result
         end
@@ -1406,6 +1445,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vlim!(result, A, b, c)
         end
         function vthrsc!(result::Vector{$T}, A::Vector{$T}, b::$T, c::$T)
+            length(result) >= length(A) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(A) ($(length(A)))"))
             LibAccelerate.$(Symbol(string("vDSP_vthrsc", suff)))(A,1,Ref(b),Ref(c),result,1,length(A))
             return result
         end
@@ -1462,6 +1503,8 @@ non-identity buffer yields a silently wrong permutation. Use the allocating
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vtabi!(D::Vector{$T}, A::Vector{$T}, s1::$T, s2::$T, C::Vector{$T})
+            length(D) >= length(A) ||
+                throw(DimensionMismatch("D length ($(length(D))) must be at least length(A) ($(length(A)))"))
             LibAccelerate.$(Symbol(string("vDSP_vtabi", suff)))(A,1,Ref(s1),Ref(s2),C,length(C),D,1,length(A))
             return D
         end
@@ -1586,6 +1629,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         vdsp_name = string("vDSP_vfix", intname, suff)
         @eval begin
             function ($fname!)(C::Vector{$intT}, A::Vector{$T})
+                length(C) >= length(A) ||
+                    throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
                 LibAccelerate.$(Symbol(vdsp_name))(A,1,C,1,length(A))
                 return C
             end
@@ -1605,6 +1650,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         vdsp_name = string("vDSP_vfixu", intname, suff)
         @eval begin
             function ($fname!)(C::Vector{$intT}, A::Vector{$T})
+                length(C) >= length(A) ||
+                    throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
                 LibAccelerate.$(Symbol(vdsp_name))(A,1,C,1,length(A))
                 return C
             end
@@ -1624,6 +1671,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         vdsp_name = string("vDSP_vfixr", intname, suff)
         @eval begin
             function ($fname!)(C::Vector{$intT}, A::Vector{$T})
+                length(C) >= length(A) ||
+                    throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
                 LibAccelerate.$(Symbol(vdsp_name))(A,1,C,1,length(A))
                 return C
             end
@@ -1643,6 +1692,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         vdsp_name = string("vDSP_vfixru", intname, suff)
         @eval begin
             function ($fname!)(C::Vector{$intT}, A::Vector{$T})
+                length(C) >= length(A) ||
+                    throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
                 LibAccelerate.$(Symbol(vdsp_name))(A,1,C,1,length(A))
                 return C
             end
@@ -1662,6 +1713,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         vdsp_name = string("vDSP_vflt", intname, suff)
         @eval begin
             function ($fname!)(C::Vector{$T}, A::Vector{$intT})
+                length(C) >= length(A) ||
+                    throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
                 LibAccelerate.$(Symbol(vdsp_name))(A,1,C,1,length(A))
                 return C
             end
@@ -1681,6 +1734,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         vdsp_name = string("vDSP_vfltu", intname, suff)
         @eval begin
             function ($fname!)(C::Vector{$T}, A::Vector{$intT})
+                length(C) >= length(A) ||
+                    throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
                 LibAccelerate.$(Symbol(vdsp_name))(A,1,C,1,length(A))
                 return C
             end

--- a/src/array.jl
+++ b/src/array.jl
@@ -1180,8 +1180,8 @@ end
 @doc "Running sum scaled by `scale`. Wraps [`vDSP_vrsum`](https://developer.apple.com/documentation/accelerate/vdsp_vrsum)." vrsum
 @doc "Simpson's rule integration with step size `step`. Wraps [`vDSP_vsimps`](https://developer.apple.com/documentation/accelerate/vdsp_vsimps)." vsimps
 @doc "Trapezoidal integration with step size `step`. Wraps [`vDSP_vtrapz`](https://developer.apple.com/documentation/accelerate/vdsp_vtrapz)." vtrapz
-@doc "Sliding window sum with window size `window`. Returns a vector of length `length(X) - window + 1`. Wraps [`vDSP_vswsum`](https://developer.apple.com/documentation/accelerate/vdsp_vswsum)." vswsum
-@doc "Sliding window maximum with window size `window`. Returns a vector of length `length(X) - window + 1`. Wraps [`vDSP_vswmax`](https://developer.apple.com/documentation/accelerate/vdsp_vswmax)." vswmax
+@doc "Sliding window sum with window size `window`. Returns a vector of length `length(X) - window + 1`. `window` must satisfy `1 ≤ window ≤ length(X)`; for `vswsum!`, `result` must have length `≥ length(X) - window + 1`. Wraps [`vDSP_vswsum`](https://developer.apple.com/documentation/accelerate/vdsp_vswsum)." vswsum
+@doc "Sliding window maximum with window size `window`. Returns a vector of length `length(X) - window + 1`. `window` must satisfy `1 ≤ window ≤ length(X)`; for `vswmax!`, `result` must have length `≥ length(X) - window + 1`. Wraps [`vDSP_vswmax`](https://developer.apple.com/documentation/accelerate/vdsp_vswmax)." vswmax
 
 # ============================================================
 # vDSP Interpolation

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -1407,4 +1407,78 @@ for T in (Float32, Float64)
     end
 end
 
+# Out-of-bounds-write guards on single-input / interpolation / conversion
+# mutating `!` methods: undersized `result`/`C` buffers must throw before the
+# C routine writes past the end of the buffer.
+for T in (Float32, Float64)
+    @testset "Bounds-check guards::$T" begin
+        X = T[1, 2, 3, 4, 5]
+        small = Vector{T}(undef, 2)   # deliberately too small
+        ok = similar(X)
+
+        # --- sliding window (A2): window range + result length ---
+        # valid call still works
+        @test AppleAccelerate.vswsum(X, 2) ≈ [X[i] + X[i+1] for i in 1:length(X)-1]
+        @test AppleAccelerate.vswmax(X, 2) ≈ [max(X[i], X[i+1]) for i in 1:length(X)-1]
+        # invalid window (allocating + mutating, sum + max)
+        @test_throws ArgumentError AppleAccelerate.vswsum(X, 0)
+        @test_throws ArgumentError AppleAccelerate.vswsum(X, length(X) + 1)
+        @test_throws ArgumentError AppleAccelerate.vswmax(X, 0)
+        @test_throws ArgumentError AppleAccelerate.vswmax(X, length(X) + 1)
+        @test_throws ArgumentError AppleAccelerate.vswsum!(Vector{T}(undef, 4), X, 0)
+        @test_throws ArgumentError AppleAccelerate.vswmax!(Vector{T}(undef, 4), X, 0)
+        # undersized result for a valid window (n_out = 4)
+        @test_throws DimensionMismatch AppleAccelerate.vswsum!(small, X, 2)
+        @test_throws DimensionMismatch AppleAccelerate.vswmax!(small, X, 2)
+
+        # --- clipping / thresholding (A1) ---
+        lo = T(2); hi = T(4); thr = T(3)
+        @test AppleAccelerate.vclip!(similar(X), X, lo, hi) ≈ clamp.(X, lo, hi)
+        @test_throws DimensionMismatch AppleAccelerate.vclip!(small, X, lo, hi)
+        @test_throws DimensionMismatch AppleAccelerate.viclip!(small, X, lo, hi)
+        @test_throws DimensionMismatch AppleAccelerate.vthr!(small, X, thr)
+        @test_throws DimensionMismatch AppleAccelerate.vthres!(small, X, thr)
+        @test_throws DimensionMismatch AppleAccelerate.vlim!(small, X, T(0), T(1))
+        @test_throws DimensionMismatch AppleAccelerate.vthrsc!(small, X, T(0), T(1))
+        @test_throws DimensionMismatch AppleAccelerate.vclipc!(small, X, lo, hi)
+
+        # --- interpolation (A1): result vs length(indices) ---
+        table = T[10, 20, 30, 40]
+        idx = T[0.0, 0.5, 1.5, 2.5]  # 4 fractional indices
+        @test length(AppleAccelerate.vlint(table, idx)) == length(idx)
+        @test_throws DimensionMismatch AppleAccelerate.vlint!(small, table, idx)
+        @test_throws DimensionMismatch AppleAccelerate.vqint!(small, table, idx)
+
+        # --- gather / index (A1 + A3): result length + index bounds ---
+        Bidx = UInt[1, 3, 5]
+        @test AppleAccelerate.vgathr(X, Bidx) ≈ T[1, 3, 5]
+        @test_throws DimensionMismatch AppleAccelerate.vgathr!(Vector{T}(undef, 1), X, Bidx)
+        @test_throws DimensionMismatch AppleAccelerate.vindex!(Vector{T}(undef, 1), X, T[0, 2, 4])
+        # A3: out-of-range 1-based index (0 and length+1) must throw
+        @test_throws BoundsError AppleAccelerate.vgathr(X, UInt[1, UInt(length(X) + 1)])
+        @test_throws BoundsError AppleAccelerate.vgathr(X, UInt[0])
+
+        # --- table lookup (A1): D vs length(A) ---
+        tab = T[1, 2, 3, 4]
+        idxA = T[0, 1, 2, 3]
+        @test AppleAccelerate.vtabi(idxA, T(1), T(0), tab) ≈ tab
+        @test_throws DimensionMismatch AppleAccelerate.vtabi!(Vector{T}(undef, 1), idxA, T(1), T(0), tab)
+
+        # --- piecewise generation (A1): C vs n ---
+        @test_throws DimensionMismatch AppleAccelerate.vgenp!(Vector{T}(undef, 2), T[1, 2], T[0, 10], 5)
+
+        # --- type conversion (A1): C vs length(A) ---
+        Xf = T[1.2, 2.7, 3.1, 4.9]
+        @test AppleAccelerate.vfix32(Xf) == Int32.(trunc.(Xf))
+        @test_throws DimensionMismatch AppleAccelerate.vfix32!(Vector{Int32}(undef, 1), Xf)
+        @test_throws DimensionMismatch AppleAccelerate.vfixu8!(Vector{UInt8}(undef, 1), Xf)
+        @test_throws DimensionMismatch AppleAccelerate.vfixr16!(Vector{Int16}(undef, 1), Xf)
+        @test_throws DimensionMismatch AppleAccelerate.vfixru32!(Vector{UInt32}(undef, 1), Xf)
+        Ai = Int32[1, 2, 3, 4]
+        @test AppleAccelerate.vflt32(Ai, T) ≈ T.(Ai)
+        @test_throws DimensionMismatch AppleAccelerate.vflt32!(Vector{T}(undef, 1), Ai)
+        @test_throws DimensionMismatch AppleAccelerate.vfltu8!(Vector{T}(undef, 1), UInt8[1, 2, 3, 4])
+    end
+end
+
 end # @testset "Array Operations"


### PR DESCRIPTION
## Problem

In `src/array.jl`, many mutating `!` methods take the element count from an **input** length and let the C routine write that many elements into the caller-supplied output buffer, with no check that the buffer is large enough. The two-vector families already validated, but the single-input, interpolation, gather, table-lookup, and type-conversion families did not — a heap out-of-bounds write if a caller passed a too-small buffer.

## Fixes (all surgical; no change to numeric behavior of valid calls)

- **Sliding window (A2)** — `vswsum!`/`vswmax!` (and allocating forms): require `1 <= window <= length(X)` (`ArgumentError`); `!` forms require `length(result) >= length(X) - window + 1` (`DimensionMismatch`).
- **Single-input clip/threshold (A1)** — `vclip!`, `viclip!`, `vthr!`, `vthres!`, `vlim!`, `vthrsc!`, `vclipc!`: require `length(result) >= length(X)`/`length(A)`.
- **Interpolation (A1)** — `vlint!`, `vqint!`: require `length(result) >= length(indices)`.
- **Gather / index / table (A1)** — `vgathr!`, `vindex!`, `vtabi!` require the output to cover the driving input length; `vgenp!` requires `length(C) >= n`.
- **Index bounds (A3)** — `vgathr!` validates each 1-based `UInt` index is in `1:length(A)` (`BoundsError`); doc updated to state the precondition.
- **Type conversion (A1)** — the whole `vfix*!`/`vfixu*!`/`vfixr*!`/`vfixru*!`/`vflt*!`/`vfltu*!` family: require `length(C) >= length(A)`.

## Tests

Added a `Bounds-check guards` testset in `test/array_tests.jl` (both `Float32`/`Float64`) asserting each guard throws on undersized/misused buffers via `@test_throws`, plus that valid calls still return correct results.

## Test result

Full suite passes (`Array Operations | 880 880`; all other suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)