### PR TITLE
cleanup: use reinterpret views instead of raw Ptr casts for interleaved complex buffers

### DIFF
--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -358,7 +358,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             interleaved_out = Vector{$T}(undef, 2 * n)
             GC.@preserve X interleaved_out begin
                 LibAccelerate.$(Symbol(string("vDSP_polar", suff)))(
-                      Ptr{$T}(pointer(X)), 2, interleaved_out, 2, n)
+                      reinterpret($T, X), 2, interleaved_out, 2, n)
             end
             magnitudes = interleaved_out[1:2:end]
             angles = interleaved_out[2:2:end]
@@ -378,7 +378,7 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             result = Vector{Complex{$T}}(undef, n)
             GC.@preserve interleaved_in result begin
                 LibAccelerate.$(Symbol(string("vDSP_rect", suff)))(
-                      interleaved_in, 2, Ptr{$T}(pointer(result)), 2, n)
+                      interleaved_in, 2, reinterpret($T, result), 2, n)
             end
             return result
         end

--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -743,27 +743,30 @@ end
 # ============================================================
 # Format conversion (interleaved ↔ split complex)
 # ============================================================
-for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
-                             (Float64, "D", :DSPDoubleSplitComplex))
+for (T, suff, DSPSplit, DSPCplx) in ((Float32, "", :DSPSplitComplex, :DSPComplex),
+                                     (Float64, "D", :DSPDoubleSplitComplex, :DSPDoubleComplex))
     @eval begin
         function ctoz(X::Vector{Complex{$T}})
             n = length(X)
             o_re = Vector{$T}(undef, n)
             o_im = Vector{$T}(undef, n)
-            GC.@preserve X o_re o_im begin
+            # X is passed as a `reinterpret` view (same memory as the interleaved
+            # `Ptr{DSPComplex}` the wrapper wants) so ccall roots it; only the
+            # split-complex backing arrays need an explicit GC.@preserve.
+            GC.@preserve o_re o_im begin
                 osplit = $DSPSplit(o_re, o_im)
                 LibAccelerate.$(Symbol(string("vDSP_ctoz", suff)))(
-                      pointer(X), 2, Ref(osplit), 1, n)
+                      reinterpret(LibAccelerate.$DSPCplx, X), 2, Ref(osplit), 1, n)
             end
             return (o_re, o_im)
         end
         function ztoc(re::Vector{$T}, im::Vector{$T})
             n = length(re)
             result = Vector{Complex{$T}}(undef, n)
-            GC.@preserve re im result begin
+            GC.@preserve re im begin
                 isplit = $DSPSplit(re, im)
                 LibAccelerate.$(Symbol(string("vDSP_ztoc", suff)))(
-                      Ref(isplit), 1, pointer(result), 2, n)
+                      Ref(isplit), 1, reinterpret(LibAccelerate.$DSPCplx, result), 2, n)
             end
             return result
         end


### PR DESCRIPTION
A small, behavior-preserving cleanup from the Ptr/Ref review: replace manual raw-pointer casts with `reinterpret` views for the interleaved-complex buffers passed to vDSP. In each case the view is a `ccall` argument, so it's GC-rooted by ccall's own contract rather than relying on a bare pointer, which reduces the raw-pointer surface.

### Changes (`src/complexarray.jl`)
- **`polar` / `rect`** — `vDSP_polar`/`vDSP_rect` take the complex buffer as `Ptr{Cfloat}`. Replaced `Ptr{T}(pointer(X))` with `reinterpret(T, X)` (interleaved real view).
- **`ctoz` / `ztoc`** — `vDSP_ctoz`/`vDSP_ztoc` take the interleaved side as `Ptr{DSPComplex}`. Replaced `pointer(X)` / `pointer(result)` with `reinterpret(DSPComplex, …)` (`DSPComplex` is `{real,imag}`, layout-identical to `Complex{T}`). The `GC.@preserve` blocks are tightened to cover only the split-complex backing arrays (`o_re`/`o_im`, `re`/`im`) that still hold raw pointers via the `DSPSplitComplex` struct.

### Verification
- `polar`/`rect` and `ctoz`/`ztoc` round-trips checked against `abs`/`angle`/`real`/`imag` reconstruction for both `Float32` and `Float64`.
- Full `Pkg.test()` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)