### PR TITLE
gen: make generator reproducible and fail loudly on drift

### DIFF
--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,3 +1,7 @@
 [deps]
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[compat]
+Clang = "=0.19.3"
+julia = "1.10"

--- a/gen/README.md
+++ b/gen/README.md
@@ -30,8 +30,24 @@ so it needs Xcode or the Command Line Tools) and overwrites `src/lib/LibAccelera
 The committed output is self-contained — **end users need only the runtime
 framework that ships with every Mac**, not the headers or Clang.jl.
 
-Generation is deterministic: re-running with the same SDK produces byte-identical
-output, so CI can regenerate and diff to catch drift when a new SDK adds symbols.
+## Reproducibility
+
+Generation is deterministic **per machine**: re-running with the same SDK *and* the
+same macOS runtime produces byte-identical output. It is not deterministic across
+machines, because:
+
+- The dead-symbol strip pass `dlopen`s the **live** framework at
+  `/System/Library/Frameworks/Accelerate.framework/Accelerate` (not the SDK), so the
+  set of stripped wrappers depends on which symbols the running macOS version exports.
+- Clang.jl names anonymous structs with a global counter (`var"##Ctag#NNN"`). These
+  names renumber **wholesale** when SDK headers add or remove any anonymous type, so
+  even a small SDK update can produce a large, mechanical diff in the committed output.
+
+There is currently no CI job that regenerates and diffs the output; drift against a
+new SDK is caught by re-running the generator manually. To make silent drift harder,
+`generate.jl` pins Clang.jl (via `Project.toml` `[compat]`) and every
+post-processing pass **errors** if an expected
+transformation finds zero matches instead of silently no-opping.
 
 ## Scope
 
@@ -46,6 +62,8 @@ coverage by appending headers to that list.
   post-processes the output to strip the `cblas_*`/`catlas_*`/`clapack_*` wrappers.
 - `LinearAlgebra/` — C++ generics, not C-mappable.
 - `Sparse/BLAS.h` dense×sparse multiply — C++ name-mangled (hand-wrapped elsewhere).
+- vImage — a separate Accelerate sub-framework (not part of vecLib), not currently
+  in scope.
 
 ## Known limitations
 
@@ -62,4 +80,4 @@ coverage by appending headers to that list.
 | `generator.toml` | Clang.jl options (module name, library, enum style, …) |
 | `prologue.jl` | Spliced into the generated module — `libacc` + BNNSGraph opaque handles |
 | `shims/bnns_graph_shim.h` | Neutralizes availability attributes that break Clang.jl |
-| `Project.toml` | Pins Clang.jl for the generator environment |
+| `Project.toml` | Generator environment; `[compat]` pins Clang.jl |

--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -14,11 +14,34 @@ cd(@__DIR__)
 
 # Resolve the SDK and vecLib header directory from the active toolchain rather
 # than hard-coding a path — this tracks whatever Xcode/CLT the developer has.
-const SDK = readchomp(`xcrun --show-sdk-path`)
+const SDK = try
+    readchomp(`xcrun --show-sdk-path`)
+catch err
+    error("`xcrun --show-sdk-path` failed — the generator needs the macOS SDK headers. " *
+          "Install Xcode or the Command Line Tools (`xcode-select --install`) and, if " *
+          "several toolchains are installed, select one with `xcode-select -s`. " *
+          "Underlying error: $(sprint(showerror, err))")
+end
+isdir(SDK) || error("SDK path reported by `xcrun --show-sdk-path` does not exist: $SDK")
 const VECLIB = joinpath(
     SDK,
     "System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers",
 )
+isdir(VECLIB) || error("vecLib header directory not found in the SDK: $VECLIB\n" *
+                       "The SDK at $SDK appears to lack the Accelerate framework headers; " *
+                       "reinstall/update Xcode or the Command Line Tools.")
+
+# The framework binary we dlopen for the dead-symbol strip pass, and the path the
+# generated bindings ccall at runtime. MUST match `const libacc = ...` in gen/prologue.jl
+# (verified below) — prologue.jl is spliced verbatim into the generated module, so the
+# two would silently diverge otherwise.
+const ACCELERATE_FRAMEWORK = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
+let prologue = read(joinpath(@__DIR__, "prologue.jl"), String)
+    expected = "const libacc = \"$ACCELERATE_FRAMEWORK\""
+    occursin(expected, prologue) || error(
+        "gen/prologue.jl no longer defines `$expected`. The `libacc` path in prologue.jl " *
+        "and `ACCELERATE_FRAMEWORK` in gen/generate.jl must stay in sync; update both.")
+end
 
 options = load_options(joinpath(@__DIR__, "generator.toml"))
 
@@ -34,6 +57,8 @@ push!(args, "-iframework", joinpath(SDK, "System", "Library", "Frameworks"))
 #     → BLAS/LAPACK are forwarded via libblastrampoline, not ccall.
 #   - LinearAlgebra/  → C++ generics, not C-mappable.
 #   - Sparse/BLAS.h   → C++ name-mangled dense×sparse multiply (hand-wrapped in sparse.jl).
+#   - vImage          → a separate Accelerate sub-framework (Accelerate.framework/
+#     Frameworks/vImage.framework), not part of vecLib and not currently in scope.
 # We include Sparse/Solve.h (the C solver API) directly rather than Sparse/Sparse.h so we
 # don't pull in the C++ BLAS.h. Likewise the BNNS umbrella + graph headers pull in the
 # struct/constant headers transitively.
@@ -51,6 +76,12 @@ headers = [
     joinpath(@__DIR__, "shims", "bnns_graph_shim.h"),
     joinpath(VECLIB, "Quadrature", "Quadrature.h"),
 ]
+let missing = filter(!isfile, headers)
+    isempty(missing) || error(
+        "Expected header(s) not found in the SDK at $SDK:\n  " * join(missing, "\n  ") *
+        "\nApple may have moved/renamed them in this SDK version; update the `headers` " *
+        "list in gen/generate.jl accordingly.")
+end
 
 ctx = create_context(headers, args, options)
 build!(ctx)
@@ -101,7 +132,7 @@ end
 # if Apple ever exports one of these, it simply stops being stripped. Wrappers whose symbol
 # resolves (the vast majority, including all the real `_Sparse*` ones) are left untouched.
 function strip_dead_symbol_wrappers!(path)
-    h = dlopen("/System/Library/Frameworks/Accelerate.framework/Accelerate")
+    h = dlopen(ACCELERATE_FRAMEWORK)
     lines = readlines(path)
     out = String[]
     funchead = r"^function\s+[A-Za-z_][A-Za-z0-9_]*\("
@@ -164,10 +195,35 @@ function fix_double_complex_typedefs!(path)
     return fixed
 end
 
+# Each post-pass below is *expected* to match something: cblas wrappers are always pulled
+# in via Sparse/Types.h, the framework always ships some unexported declarations, and
+# Clang.jl (as pinned) always mis-emits the two double-complex typedefs. A zero-match pass
+# therefore means Clang.jl's output format drifted and the pass silently no-oped — which
+# for `fix_double_complex_typedefs!` would silently reintroduce the ComplexF64-truncation
+# bug fixed in PR #158. Fail loudly instead of committing broken bindings.
 out_path = joinpath(@__DIR__, "..", "src", "lib", "LibAccelerate.jl")
+
 removed = strip_out_of_scope_blas!(out_path)
+removed > 0 || error(
+    "strip_out_of_scope_blas! removed no `cblas_*`/`catlas_*`/`clapack_*` wrappers. " *
+    "These are always pulled in transitively via Sparse/Types.h, so a zero count means " *
+    "Clang.jl's emitted wrapper format changed and the pass no-oped. Inspect $out_path " *
+    "and update the pass (or, if BLAS really is no longer pulled in, update this check).")
 @info "Stripped $removed out-of-scope BLAS/LAPACK wrappers (forwarded via libblastrampoline)"
+
 dead = strip_dead_symbol_wrappers!(out_path)
+isempty(dead) && error(
+    "strip_dead_symbol_wrappers! removed no wrappers. The headers always declare symbols " *
+    "the framework does not export (Sparse/Solve.h overloadable inlines, header-only BNNS " *
+    "graph setters), so a zero count means the `@ccall libacc.<sym>` pattern no longer " *
+    "matches Clang.jl's output and unresolvable wrappers were left in $out_path. " *
+    "Update the pass's regexes to match the new format.")
 @info "Stripped $(length(dead)) wrappers whose ccall symbol does not exist in the framework" dead
+
 fixed = fix_double_complex_typedefs!(out_path)
+fixed == 2 || error(
+    "fix_double_complex_typedefs! rewrote $fixed typedef line(s), expected exactly 2 " *
+    "(`__double_complex_t` and `__SPARSE_double_complex`). If Clang.jl now emits these " *
+    "correctly as ComplexF64, delete this pass; otherwise the emitted form drifted and " *
+    "the double-complex truncation bug (PR #158) is back in $out_path — fix the pass.")
 @info "Corrected $fixed double-precision complex typedef(s) (Clang.jl anonymous-_Complex bug)"

--- a/gen/prologue.jl
+++ b/gen/prologue.jl
@@ -1,6 +1,8 @@
 # Accelerate ships as a macOS *system framework*. Unlike the usual Clang.jl + JLL
 # flow, there is no artifact to load — every Mac already has it. We ccall it by
 # absolute path, mirroring the `libacc` const in the top-level AppleAccelerate module.
+# NOTE: must stay in sync with `ACCELERATE_FRAMEWORK` in gen/generate.jl, which dlopens
+# the same binary for its dead-symbol strip pass and verifies this line at generation time.
 const libacc = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
 
 # BNNSGraph opaque handles. In bnns_graph.h these are anonymous structs that all share the


### PR DESCRIPTION
An audit found the binding generator's reproducibility claims in `gen/` were not backed by reality. This PR hardens the generator tooling and docs only — `src/lib/LibAccelerate.jl` is deliberately **not** regenerated.

## Changes

- **Pin Clang.jl for real.** `gen/README.md` claimed `Project.toml` "pins Clang.jl", but there was no `[compat]` block and `gen/Manifest.toml` was gitignored (the root `Manifest.toml` pattern matches at all levels), so a fresh clone resolved an arbitrary Clang.jl version. Now: `[compat] Clang = "=0.19.3"` (the version used to emit the committed bindings). No Manifest is committed — the exact-version compat pin is the reproducibility mechanism.
- **Post-passes fail loudly on drift.** The three post-processing passes in `gen/generate.jl` (`strip_out_of_scope_blas!`, `strip_dead_symbol_wrappers!`, `fix_double_complex_typedefs!`) silently no-opped if Clang.jl's output format drifted. In particular `fix_double_complex_typedefs!` hard-matches the exact strings `const __double_complex_t = ComplexF32` / `const __SPARSE_double_complex = ComplexF32` — zero matches would silently reintroduce the ComplexF64-truncation bug fixed in #158. Each pass now errors with an actionable message when it finds no (or the wrong number of) matches.
- **Preflight checks.** Actionable errors when `xcrun --show-sdk-path` fails (points at installing/selecting Xcode or the CLT), when the vecLib header directory is missing from the SDK, and when any listed header does not exist.
- **De-duplicate the framework path.** The hardcoded `/System/Library/Frameworks/Accelerate.framework/Accelerate` appeared in both `gen/prologue.jl` (`libacc`) and `gen/generate.jl` (dlopen probe). `generate.jl` now defines `ACCELERATE_FRAMEWORK` once, uses it for the dead-symbol probe, and verifies at generation time that `prologue.jl`'s `libacc` line matches it; both sites carry cross-referencing comments.
- **Correct README overclaims.** "Generation is deterministic … so CI can regenerate and diff" was wrong on both counts: the dead-symbol strip pass dlopens the *live* framework, so output varies with the running macOS version, and no CI job runs the generator. The README now states determinism is per machine (same SDK + same macOS runtime) and documents the `var"##Ctag#NNN"` anonymous-struct renumbering hazard (counter-based names shift wholesale when SDK headers change).
- **Document vImage exclusion** (separate Accelerate sub-framework, not part of vecLib, not currently in scope) in both the `generate.jl` scope comment and the README.

## Verification

- `julia --project=. -e 'using AppleAccelerate'` — package loads; nothing under `src/` changed.
- `gen/generate.jl` and `gen/prologue.jl` parse cleanly (`Meta.parseall` with error-node check).
- `julia --project=gen` instantiates/resolves with the pinned Clang.jl 0.19.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtsEH6hQnoLvfExpA62cSF
