### PR TITLE
Add missing length guards to mutating kernels and NULL-checks to setup constructors

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -449,6 +449,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
             """ ->
             function ($f!)(result::Vector{$T}, X::Vector{$T}, c::$T)
+                length(result) == length(X) ||
+                    throw(DimensionMismatch("result and X must have the same length"))
                 LibAccelerate.$(Symbol(string("vDSP_", f, suff)))(X, 1, Ref(c), result, 1, length(result))
                 return result
             end
@@ -479,6 +481,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
         """ ->
         function ($f!)(result::Vector{$T}, X::Vector{$T}, c::$T)
+            length(result) == length(X) ||
+                throw(DimensionMismatch("result and X must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vsadd", suff)))(X, 1, Ref(-c), result, 1, length(result))
             return result
         end
@@ -509,6 +513,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         the result vector with computed value. *Returns:* **Vector{$($T)}** `result`
         """ ->
         function ($f!)(result::Vector{$T}, X::Vector{$T}, c::$T)
+            length(result) == length(X) ||
+                throw(DimensionMismatch("result and X must have the same length"))
             # c - X == X * (-1) + c, computed in one pass via vDSP_vsmsa (D = A*B + C)
             LibAccelerate.$(Symbol(string("vDSP_vsmsa", suff)))(X, 1, Ref(-one($T)), Ref(c), result, 1, length(result))
             return result
@@ -562,6 +568,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
         f! = Symbol("$(f)!")
         @eval begin
             function ($f!)(result::Vector{$T}, X::Vector{$T})
+                length(result) >= length(X) ||
+                    throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
                 LibAccelerate.$(Symbol(string("vDSP_", fa, suff)))(X,1,result,1,length(X))
                 return result
             end
@@ -619,6 +627,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
 
     @eval begin
         function vtmerg!(result::Vector{$T}, X::Vector{$T}, Y::Vector{$T})
+            (length(X) == length(Y) == length(result)) ||
+                throw(DimensionMismatch("result, X and Y must have the same length"))
             LibAccelerate.$(Symbol(string("vDSP_vtmerg", suff)))(X,1,Y,1,result,1,length(X))
             return result
         end
@@ -643,6 +653,8 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function svdiv!(result::Vector{$T}, X::Vector{$T}, c::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_svdiv", suff)))(Ref(c),X,1,result,1,length(X))
             return result
         end
@@ -1061,6 +1073,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             return result
         end
         function vrampmul!(result::Vector{$T}, X::Vector{$T}, start::$T, step::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             s = Ref{$T}(start)
             LibAccelerate.$(Symbol(string("vDSP_vrampmul", suff)))(X,1,s,Ref(step),result,1,length(X))
             return result
@@ -1119,6 +1133,8 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vrsum!(result::Vector{$T}, X::Vector{$T}, scale::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vrsum", suff)))(X,1,Ref(scale),result,1,length(X))
             return result
         end
@@ -1127,6 +1143,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vrsum!(result, X, scale)
         end
         function vsimps!(result::Vector{$T}, X::Vector{$T}, step::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vsimps", suff)))(X,1,Ref(step),result,1,length(X))
             return result
         end
@@ -1135,6 +1153,8 @@ for (T, suff) in ((Float32, ""), (Float64, "D"))
             vsimps!(result, X, step)
         end
         function vtrapz!(result::Vector{$T}, X::Vector{$T}, step::$T)
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vtrapz", suff)))(X,1,Ref(step),result,1,length(X))
             return result
         end
@@ -1233,6 +1253,8 @@ end
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vpoly!(result::Vector{$T}, coeffs::Vector{$T}, X::Vector{$T})
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             LibAccelerate.$(Symbol(string("vDSP_vpoly", suff)))(coeffs,1,X,1,result,1,length(X),length(coeffs) - 1)
             return result
         end
@@ -1257,6 +1279,8 @@ Evaluate polynomial at each point in `X`. Coefficients are highest degree first:
 for (T, suff) in ((Float32, ""), (Float64, "D"))
     @eval begin
         function vnormalize!(result::Vector{$T}, X::Vector{$T})
+            length(result) >= length(X) ||
+                throw(DimensionMismatch("result length ($(length(result))) must be at least length(X) ($(length(X)))"))
             mean_out = Ref{$T}(0.0)
             stddev_out = Ref{$T}(0.0)
             LibAccelerate.$(Symbol(string("vDSP_normalize", suff)))(X,1,result,1,mean_out,stddev_out,length(X))
@@ -1519,6 +1543,8 @@ end
 
 # --- Integer operations (Int32) ---
 function vaddi!(C::Vector{Int32}, A::Vector{Int32}, B::Vector{Int32})
+    (length(A) == length(B) == length(C)) ||
+        throw(DimensionMismatch("C, A and B must have the same length"))
     LibAccelerate.vDSP_vaddi(A,1,B,1,C,1,length(A))
     return C
 end
@@ -1528,6 +1554,8 @@ function vaddi(A::Vector{Int32}, B::Vector{Int32})
 end
 
 function vabsi!(C::Vector{Int32}, A::Vector{Int32})
+    length(C) >= length(A) ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($(length(A)))"))
     LibAccelerate.vDSP_vabsi(A,1,C,1,length(A))
     return C
 end
@@ -1542,6 +1570,8 @@ function vfilli!(C::Vector{Int32}, a::Int32)
 end
 
 function veqvi!(C::Vector{Int32}, A::Vector{Int32}, B::Vector{Int32})
+    (length(A) == length(B) == length(C)) ||
+        throw(DimensionMismatch("C, A and B must have the same length"))
     LibAccelerate.vDSP_veqvi(A,1,B,1,C,1,length(A))
     return C
 end

--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -761,6 +761,8 @@ for (T, suff, DSPSplit, DSPCplx) in ((Float32, "", :DSPSplitComplex, :DSPComplex
             return (o_re, o_im)
         end
         function ztoc(re::Vector{$T}, im::Vector{$T})
+            length(re) == length(im) ||
+                throw(DimensionMismatch("re and im must have the same length"))
             n = length(re)
             result = Vector{Complex{$T}}(undef, n)
             GC.@preserve re im begin

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -230,6 +230,7 @@ for (T, suff, Dsuff) in ((Float64, "D", "D"), (Float32, "", ""))
             setup = ccall(($(string("vDSP_biquad_CreateSetup", Dsuff), libacc)),  Ptr{Cvoid},
                           (Ptr{Float64}, UInt64),
                           coefficients, sections)
+            setup == C_NULL && error("vDSP_biquad_CreateSetup$($Dsuff) failed to create a setup for $sections section(s)")
             return Biquad($T, setup, sections)
         end
     end
@@ -336,6 +337,7 @@ for (T, suff, Dsuff) in ((Float32, "", ""), (Float64, "D", "D"))
             setup = ccall(($(string("vDSP_biquadm_CreateSetup", Dsuff)), libacc), Ptr{Cvoid},
                           (Ptr{Float64}, UInt64, UInt64),
                           coefficients, sections, channels)
+            setup == C_NULL && error("vDSP_biquadm_CreateSetup$($Dsuff) failed to create a setup for $channels channel(s) and $sections section(s)")
             return BiquadMulti($T, setup, channels, sections)
         end
 
@@ -784,6 +786,7 @@ function plan_dct(length::Int,  dct_type::Int, previous=C_NULL)
     setup::Ptr{Cvoid} = ccall(("vDSP_DCT_CreateSetup", libacc), Ptr{Cvoid},
                              (Ptr{Cvoid}, UInt64, UInt64),
                              previous, length, dct_type)
+    setup == C_NULL && error("vDSP_DCT_CreateSetup failed to create a setup for length $length and DCT type $dct_type")
     return DFTSetup(Float32, setup, 0)
 end
 

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -1478,7 +1478,60 @@ for T in (Float32, Float64)
         @test AppleAccelerate.vflt32(Ai, T) ≈ T.(Ai)
         @test_throws DimensionMismatch AppleAccelerate.vflt32!(Vector{T}(undef, 1), Ai)
         @test_throws DimensionMismatch AppleAccelerate.vfltu8!(Vector{T}(undef, 1), UInt8[1, 2, 3, 4])
+
+        # --- unary ops: undersized result must throw ---
+        @test_throws DimensionMismatch AppleAccelerate.vneg!(small, X)
+        @test_throws DimensionMismatch AppleAccelerate.vnabs!(small, X)
+        @test_throws DimensionMismatch AppleAccelerate.vsq!(small, X)
+        @test_throws DimensionMismatch AppleAccelerate.vssq!(small, X)
+        @test_throws DimensionMismatch AppleAccelerate.vfrac!(small, X)
+        @test_throws DimensionMismatch AppleAccelerate.vabs!(small, X)
+
+        # --- vector-scalar ops: result and X must match (count is taken
+        #     from result, so an oversized result would read past X) ---
+        big = Vector{T}(undef, length(X) + 3)
+        c = T(2)
+        @test_throws DimensionMismatch AppleAccelerate.vsadd!(small, X, c)
+        @test_throws DimensionMismatch AppleAccelerate.vsadd!(big, X, c)
+        @test_throws DimensionMismatch AppleAccelerate.vsdiv!(big, X, c)
+        @test_throws DimensionMismatch AppleAccelerate.vsmul!(big, X, c)
+        @test_throws DimensionMismatch AppleAccelerate.vssub!(big, X, c)
+        @test_throws DimensionMismatch AppleAccelerate.svsub!(big, X, c)
+
+        # --- scalar / vector divide ---
+        @test_throws DimensionMismatch AppleAccelerate.svdiv!(small, X, c)
+
+        # --- tapered merge: all three lengths must match ---
+        @test_throws DimensionMismatch AppleAccelerate.vtmerg!(small, X, X)
+        @test_throws DimensionMismatch AppleAccelerate.vtmerg!(ok, X, T[1, 2])
+
+        # --- ramp multiply ---
+        @test_throws DimensionMismatch AppleAccelerate.vrampmul!(small, X, T(0), T(1))
+
+        # --- integration / running ops ---
+        @test_throws DimensionMismatch AppleAccelerate.vrsum!(small, X, T(1))
+        @test_throws DimensionMismatch AppleAccelerate.vsimps!(small, X, T(1))
+        @test_throws DimensionMismatch AppleAccelerate.vtrapz!(small, X, T(1))
+
+        # --- polynomial evaluation ---
+        @test_throws DimensionMismatch AppleAccelerate.vpoly!(small, T[1, 0], X)
+
+        # --- normalization ---
+        @test_throws DimensionMismatch AppleAccelerate.vnormalize!(small, X)
     end
+end
+
+# Int32 mutating ops: mismatched buffers must throw before the C routine
+# reads or writes out of bounds.
+@testset "Bounds-check guards::Int32" begin
+    Ai = Int32[1, -2, 3, -4, 5]
+    Bi = Int32[1, 2, 3, 4, 5]
+    smalli = Vector{Int32}(undef, 2)
+    @test_throws DimensionMismatch AppleAccelerate.vaddi!(smalli, Ai, Bi)
+    @test_throws DimensionMismatch AppleAccelerate.vaddi!(similar(Ai), Ai, Int32[1, 2])
+    @test_throws DimensionMismatch AppleAccelerate.vabsi!(smalli, Ai)
+    @test_throws DimensionMismatch AppleAccelerate.veqvi!(smalli, Ai, Bi)
+    @test_throws DimensionMismatch AppleAccelerate.veqvi!(similar(Ai), Ai, Int32[1, 2])
 end
 
 end # @testset "Array Operations"

--- a/test/complexarray_tests.jl
+++ b/test/complexarray_tests.jl
@@ -323,6 +323,10 @@ for T in (Float32, Float64)
         re2, im2 = AppleAccelerate.ctoz(AppleAccelerate.ztoc(re, im))
         @test re2 == re
         @test im2 == im
+
+        # mismatched re/im lengths must throw (count is taken from re, so a
+        # shorter im would be read out of bounds)
+        @test_throws DimensionMismatch AppleAccelerate.ztoc(re, im[1:end-1])
     end
 end
 


### PR DESCRIPTION
A code audit found several mutating (`!`) kernels that pass an element count taken from one argument to vDSP while leaving the other buffers unchecked, allowing reachable out-of-bounds reads/writes from the public API. This PR adds `DimensionMismatch` guards matching the style already used elsewhere in the same files (e.g. `vadd!`, `vmax!`, `vclip!`, the compound-arithmetic ops), plus NULL-checks on setup constructors.

## Out-of-bounds write fixed (count from input, `result` unchecked)

- `vneg!` / `vnabs!` / `vsq!` / `vssq!` / `vfrac!` / `vabs!` (unary family, `src/array.jl`)
- `svdiv!`
- `vtmerg!` (had no checks at all; now requires `result`, `X`, `Y` same length)
- `vrampmul!`
- `vrsum!` / `vsimps!` / `vtrapz!`
- `vpoly!`
- `vnormalize!`
- Int32 ops `vaddi!` / `vabsi!` / `veqvi!`

## Out-of-bounds read fixed (count from `result`, input unchecked)

- `vsadd!` / `vsdiv!` / `vsmul!` / `vssub!` / `svsub!` — these take the count from `length(result)`, so an oversized `result` read past the end of `X`; they now require `length(result) == length(X)`

## Out-of-bounds read fixed in `ztoc` (`src/complexarray.jl`)

- `ztoc(re, im)` took the count from `length(re)` and never checked `im`, so a shorter `im` was read past its end; now requires `length(re) == length(im)`

## NULL-checks on setup constructors (`src/dsp.jl`)

Consistent with the existing `setup == C_NULL` check in `plan_dft`:

- `biquadcreate`
- `biquadm_create`
- `plan_dct`

A failed vDSP setup now raises an informative error instead of returning a wrapper around a NULL pointer that crashes on first use.

## Tests

- `@test_throws DimensionMismatch` cases for every newly guarded function, added to the existing bounds-check-guard testsets in `test/array_tests.jl` (including a new Int32 testset) and to the `ctoz/ztoc` testset in `test/complexarray_tests.jl`.
- Full test suite passes locally on macOS (`Pkg.test()`: 5205 tests, all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtsEH6hQnoLvfExpA62cSF