### PR TITLE
ci: add JETLS static-analysis check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+  jetls_check:
+    name: JETLS check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: aviatesk/JETLS.jl/.github/actions/check@release
+        with:
+          files: src/AppleAccelerate.jl
   docs:
     name: Documentation
     runs-on: macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   jetls_check:
     name: JETLS check
-    runs-on: ubuntu-latest
+    # macOS runner: on Linux the Sys.isapple() branches are inactive, so JETLS
+    # flags Apple-only globals (e.g. LIBSPARSE) as undefined.
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v7
       - uses: aviatesk/JETLS.jl/.github/actions/check@release


### PR DESCRIPTION
Adds the `jetls check` GitHub Action to CI, as recommended by @aviatesk in #120, running static analysis on `src/AppleAccelerate.jl` on every PR and push to master.

Uses the action provided by the JETLS side (`aviatesk/JETLS.jl/.github/actions/check@release`), so no manual JETLS installation is needed in the workflow.

Closes the CI follow-up from #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtsEH6hQnoLvfExpA62cSF