### PR TITLE
complexarray: add zmsm, zvmmaa, zrdesamp (complex matmul family)

### DIFF
--- a/docs/src/complex.md
+++ b/docs/src/complex.md
@@ -75,6 +75,9 @@ The complex-valued docstrings for `vneg` and `vabs` are rendered alongside the r
 | [`zmmul`](@ref AppleAccelerate.zmmul) | Complex matrix multiply: `A * B` |
 | [`zmma`](@ref AppleAccelerate.zmma) | Complex matrix multiply-add: `A * B + C` |
 | [`zmms`](@ref AppleAccelerate.zmms) | Complex matrix multiply-subtract: `A * B - C` |
+| [`zmsm`](@ref AppleAccelerate.zmsm) | Complex matrix multiply and reverse-subtract: `C - A*B` |
+| [`zvmmaa`](@ref AppleAccelerate.zvmmaa) | Elementwise multiply-multiply-add-add: `A*B + C*D + E` |
+| [`zrdesamp`](@ref AppleAccelerate.zrdesamp) | Complex-real decimating resample/correlation |
 
 ## Coordinate conversion
 
@@ -134,6 +137,9 @@ AppleAccelerate.zconv
 AppleAccelerate.zmmul
 AppleAccelerate.zmma
 AppleAccelerate.zmms
+AppleAccelerate.zmsm
+AppleAccelerate.zvmmaa
+AppleAccelerate.zrdesamp
 AppleAccelerate.ctoz
 AppleAccelerate.ztoc
 ```

--- a/src/complexarray.jl
+++ b/src/complexarray.jl
@@ -809,6 +809,156 @@ end
 @doc "Complex matrix multiply-subtract: `D = A * B - C`. `C` and `D` are `size(A,1)×size(B,2)`. The `zmms!(D, A, B, C)` form writes into `D`. Wraps [`vDSP_zmms`](https://developer.apple.com/documentation/accelerate/vdsp_zmms)." zmms
 
 # ============================================================
+# Complex matrix multiply-add / multiply-subtract / reverse-subtract,
+# vector multiply-multiply-add-add, and complex-real decimating resample.
+#
+# zmma/zmms/zmsm share zmmul's row-major ↔ col-major operand swap: pass
+# (B, A, C, D) with dims (n, m, p) instead of (A, B, C, D) with (m, n, p).
+# The elementwise operand C composes cleanly under the swap (verified
+# empirically, see PR notes / project memory): reading Julia's m×n C as a
+# row-major n×m matrix always yields C^T under the same convention used for
+# the output D, so the transpose cancels exactly as it does for A*B in
+# zmmul. This works for zmsm too because its C-level formula is the reverse
+# subtract D = C − A*B (confirmed by direct ccall probing against the
+# vDSP.h header comment "matrix multiply and reverse subtract"), NOT
+# `(A-B)*C` — a plausible-looking guess from the name that is not what the
+# framework computes. Because D = C − A*B decomposes as (elementwise C) −
+# (matrix product A*B), and both pieces transpose consistently, no extra
+# copy is needed.
+# ============================================================
+for (T, suff, DSPSplit) in ((Float32, "", :DSPSplitComplex),
+                            (Float64, "D", :DSPDoubleSplitComplex))
+
+    # zmsm: D = C - A*B (vDSP's "reverse subtract"; verified empirically —
+    # NOT (A-B)*C, see the section note above)
+    @eval begin
+        function zmsm!(D::Matrix{Complex{$T}}, A::Matrix{Complex{$T}}, B::Matrix{Complex{$T}}, C::Matrix{Complex{$T}})
+            m, p = size(A)
+            p2, n = size(B)
+            p == p2 || throw(DimensionMismatch("A columns ($p) ≠ B rows ($p2)"))
+            size(C) == (m, n) || throw(DimensionMismatch("C must be $m×$n"))
+            size(D) == (m, n) || throw(DimensionMismatch("D must be $m×$n"))
+            GC.@preserve A B C D begin
+                asplit = _split_view($DSPSplit, pointer(A))
+                bsplit = _split_view($DSPSplit, pointer(B))
+                csplit = _split_view($DSPSplit, pointer(C))
+                dsplit = _split_view($DSPSplit, pointer(D))
+                LibAccelerate.$(Symbol(string("vDSP_zmsm", suff)))(
+                      Ref(bsplit), _CSTRIDE, Ref(asplit), _CSTRIDE, Ref(csplit), _CSTRIDE, Ref(dsplit), _CSTRIDE,
+                      UInt64(n), UInt64(m), UInt64(p))
+            end
+            return D
+        end
+        @doc """
+            zmsm(A::Matrix{Complex{$($T)}}, B::Matrix{Complex{$($T)}}, C::Matrix{Complex{$($T)}}) -> Matrix{Complex{$($T)}}
+            zmsm!(D, A, B, C)
+
+        Complex matrix multiply and reverse-subtract: `D = C - A*B`.
+        Wraps [`vDSP_zmsm`](https://developer.apple.com/documentation/accelerate/vdsp_zmsm)
+        (the vDSP.h header labels this "matrix multiply and reverse subtract";
+        confirmed empirically to compute `C - A*B`, not `(A-B)*C`).
+        """
+        function zmsm(A::Matrix{Complex{$T}}, B::Matrix{Complex{$T}}, C::Matrix{Complex{$T}})
+            m = size(A, 1)
+            n = size(B, 2)
+            D = Matrix{Complex{$T}}(undef, m, n)
+            zmsm!(D, A, B, C)
+        end
+    end
+
+    # zvmmaa: F = A*B + C*D + E (elementwise complex vectors; "vector
+    # multiply, multiply, add, and add" — verified empirically that the 5th
+    # operand E is a genuine additive term, not unused)
+    @eval begin
+        function zvmmaa!(F::Vector{Complex{$T}}, A::Vector{Complex{$T}}, B::Vector{Complex{$T}}, C::Vector{Complex{$T}}, D::Vector{Complex{$T}}, E::Vector{Complex{$T}})
+            n = length(A)
+            (length(B) == n && length(C) == n && length(D) == n && length(E) == n && length(F) == n) ||
+                throw(DimensionMismatch("zvmmaa!: A, B, C, D, E, and F must have equal lengths"))
+            GC.@preserve A B C D E F begin
+                asplit = _split_view($DSPSplit, pointer(A))
+                bsplit = _split_view($DSPSplit, pointer(B))
+                csplit = _split_view($DSPSplit, pointer(C))
+                dsplit = _split_view($DSPSplit, pointer(D))
+                esplit = _split_view($DSPSplit, pointer(E))
+                fsplit = _split_view($DSPSplit, pointer(F))
+                LibAccelerate.$(Symbol(string("vDSP_zvmmaa", suff)))(
+                      Ref(asplit), _CSTRIDE, Ref(bsplit), _CSTRIDE, Ref(csplit), _CSTRIDE,
+                      Ref(dsplit), _CSTRIDE, Ref(esplit), _CSTRIDE, Ref(fsplit), _CSTRIDE, n)
+            end
+            return F
+        end
+        @doc """
+            zvmmaa(A::Vector{Complex{$($T)}}, B::Vector{Complex{$($T)}}, C::Vector{Complex{$($T)}}, D::Vector{Complex{$($T)}}, E::Vector{Complex{$($T)}}) -> Vector{Complex{$($T)}}
+            zvmmaa!(F, A, B, C, D, E)
+
+        Elementwise vector multiply-multiply-add-add: `F[i] = A[i]*B[i] + C[i]*D[i] + E[i]`.
+        Wraps [`vDSP_zvmmaa`](https://developer.apple.com/documentation/accelerate/vdsp_zvmmaa).
+        """
+        function zvmmaa(A::Vector{Complex{$T}}, B::Vector{Complex{$T}}, C::Vector{Complex{$T}}, D::Vector{Complex{$T}}, E::Vector{Complex{$T}})
+            F = similar(A)
+            zvmmaa!(F, A, B, C, D, E)
+        end
+    end
+
+    # zrdesamp: complex-real decimating resample/correlation.
+    # C[n] = sum(A[n*DF+p] * F[p], 0 <= p < P)  (0-indexed; matches vDSP.h's
+    # "Maps" comment, and the real-valued `desamp` this mirrors).
+    #
+    # Unlike zmma/zmms/zmsm/zvmmaa, vDSP_zrdesamp takes NO stride argument
+    # for its split-complex operands ("No strides are used; arrays map
+    # directly to memory" — vDSP.h) — it reads/writes the realp/imagp
+    # buffers as fully contiguous arrays. This file's usual pointer trick
+    # (`_split_view` over an interleaved Complex{T} buffer with an explicit
+    # stride of `_CSTRIDE=2`) therefore does NOT apply here: verified
+    # empirically that feeding it interleaved storage silently produces
+    # wrong results (each of realp/imagp gets alternating real/imag values).
+    # So this wrapper deinterleaves into genuine contiguous real/imag
+    # buffers (à la `ctoz`/`ztoc`) rather than reusing `_split_view`.
+    @eval begin
+        function zrdesamp!(C::Vector{Complex{$T}}, A::Vector{Complex{$T}}, DF::Int, F::Vector{$T})
+            length(A) >= length(F) ||
+                error("length(A) ($(length(A))) must be >= length(F) ($(length(F)))")
+            P = length(F)
+            nout = div(length(A) - P, DF) + 1
+            length(C) >= nout || error("C must have at least $(nout) elements")
+            Are = $T[real(a) for a in A]
+            Aim = $T[imag(a) for a in A]
+            Cre = Vector{$T}(undef, nout)
+            Cim = Vector{$T}(undef, nout)
+            GC.@preserve Are Aim F Cre Cim begin
+                asplit = $DSPSplit(pointer(Are), pointer(Aim))
+                csplit = $DSPSplit(pointer(Cre), pointer(Cim))
+                LibAccelerate.$(Symbol(string("vDSP_zrdesamp", suff)))(
+                      Ref(asplit), DF, F, Ref(csplit), UInt64(nout), UInt64(P))
+            end
+            @inbounds for i in 1:nout
+                C[i] = Complex{$T}(Cre[i], Cim[i])
+            end
+            return C
+        end
+        @doc """
+            zrdesamp(A::Vector{Complex{$($T)}}, DF::Int, F::Vector{$($T)}) -> Vector{Complex{$($T)}}
+            zrdesamp!(C, A, DF, F)
+
+        Complex-real decimating resample/correlation using `vDSP_zrdesamp`.
+        Filters complex input `A` with real FIR coefficients `F` (`P` taps)
+        and decimation factor `DF`. `C` must have at least
+        `div(length(A) - P, DF) + 1` elements.
+        Computes: `C[n] = sum(A[n*DF+p] * F[p] for p in 0:P-1)` (0-indexed).
+        Wraps [`vDSP_zrdesamp`](https://developer.apple.com/documentation/accelerate/vdsp_zrdesamp).
+        """
+        function zrdesamp(A::Vector{Complex{$T}}, DF::Int, F::Vector{$T})
+            length(A) >= length(F) ||
+                error("length(A) ($(length(A))) must be >= length(F) ($(length(F)))")
+            P = length(F)
+            nout = div(length(A) - P, DF) + 1
+            C = Vector{Complex{$T}}(undef, nout)
+            zrdesamp!(C, A, DF, F)
+        end
+    end
+end
+
+# ============================================================
 # Format conversion (interleaved ↔ split complex)
 # ============================================================
 for (T, suff, DSPSplit, DSPCplx) in ((Float32, "", :DSPSplitComplex, :DSPComplex),

--- a/test/complexarray_tests.jl
+++ b/test/complexarray_tests.jl
@@ -389,4 +389,125 @@ for T in (Float32, Float64)
     end
 end
 
+# ============================================================
+# Complex matrix multiply-add / multiply-subtract / reverse-subtract
+# (zmma, zmms, zmsm), vector multiply-multiply-add-add (zvmmaa), and
+# complex-real decimating resample (zrdesamp)
+# ============================================================
+for T in (Float32, Float64)
+    @testset "Complex Matrix Multiply-Add/Subtract::$T" begin
+        # non-square, non-symmetric so a layout/order bug fails loudly
+        m, p, n = 4, 3, 5
+        A = complex.(randn(T, m, p), randn(T, m, p))
+        B = complex.(randn(T, p, n), randn(T, p, n))
+        C = complex.(randn(T, m, n), randn(T, m, n))
+        rtol = T == Float32 ? sqrt(eps(Float32)) : sqrt(eps(Float64))
+
+        # zmma: D = A*B + C
+        D = AppleAccelerate.zmma(A, B, C)
+        @test D ≈ A * B .+ C rtol=rtol
+        D2 = Matrix{Complex{T}}(undef, m, n)
+        AppleAccelerate.zmma!(D2, A, B, C)
+        @test D2 ≈ A * B .+ C rtol=rtol
+
+        # zmms: D = A*B - C
+        D3 = AppleAccelerate.zmms(A, B, C)
+        @test D3 ≈ A * B .- C rtol=rtol
+        D4 = Matrix{Complex{T}}(undef, m, n)
+        AppleAccelerate.zmms!(D4, A, B, C)
+        @test D4 ≈ A * B .- C rtol=rtol
+
+        # zmsm: D = C - A*B (vDSP's reverse subtract, confirmed empirically —
+        # NOT (A-B)*C)
+        D5 = AppleAccelerate.zmsm(A, B, C)
+        @test D5 ≈ C .- A * B rtol=rtol
+        D6 = Matrix{Complex{T}}(undef, m, n)
+        AppleAccelerate.zmsm!(D6, A, B, C)
+        @test D6 ≈ C .- A * B rtol=rtol
+
+        # DimensionMismatch guards
+        Bbad = complex.(randn(T, p + 1, n), randn(T, p + 1, n))
+        @test_throws DimensionMismatch AppleAccelerate.zmma(A, Bbad, C)
+        @test_throws DimensionMismatch AppleAccelerate.zmms(A, Bbad, C)
+        @test_throws DimensionMismatch AppleAccelerate.zmsm(A, Bbad, C)
+        Cbad = complex.(randn(T, m, n + 1), randn(T, m, n + 1))
+        @test_throws DimensionMismatch AppleAccelerate.zmma(A, B, Cbad)
+        @test_throws DimensionMismatch AppleAccelerate.zmms(A, B, Cbad)
+        @test_throws DimensionMismatch AppleAccelerate.zmsm(A, B, Cbad)
+        Dbad = Matrix{Complex{T}}(undef, m, n + 1)
+        @test_throws DimensionMismatch AppleAccelerate.zmma!(Dbad, A, B, C)
+        @test_throws DimensionMismatch AppleAccelerate.zmms!(Dbad, A, B, C)
+        @test_throws DimensionMismatch AppleAccelerate.zmsm!(Dbad, A, B, C)
+    end
+
+    @testset "Complex Vector Multiply-Multiply-Add-Add (zvmmaa)::$T" begin
+        Av::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
+        Bv::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
+        Cv::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
+        Dv::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
+        Ev::Vector{Complex{T}} = complex.(randn(T, N), randn(T, N))
+        rtol = T == Float32 ? sqrt(eps(Float32)) : sqrt(eps(Float64))
+
+        ref = Av .* Bv .+ Cv .* Dv .+ Ev
+        F = AppleAccelerate.zvmmaa(Av, Bv, Cv, Dv, Ev)
+        @test F ≈ ref rtol=rtol
+
+        F2 = similar(Av)
+        @test AppleAccelerate.zvmmaa!(F2, Av, Bv, Cv, Dv, Ev) === F2
+        @test F2 ≈ ref rtol=rtol
+
+        bad = similar(Av, N - 1)
+        @test_throws DimensionMismatch AppleAccelerate.zvmmaa!(bad, Av, Bv, Cv, Dv, Ev)
+        @test_throws DimensionMismatch AppleAccelerate.zvmmaa!(F2, bad, Bv, Cv, Dv, Ev)
+    end
+
+    @testset "Complex-Real Decimating Resample (zrdesamp)::$T" begin
+        Av::Vector{Complex{T}} = complex.(randn(T, 41), randn(T, 41))
+        Fv::Vector{T} = randn(T, 7)
+        DF = 3
+        rtol = T == Float32 ? sqrt(eps(Float32)) : sqrt(eps(Float64))
+
+        P = length(Fv)
+        Nout = div(length(Av) - P, DF) + 1
+
+        Cv = AppleAccelerate.zrdesamp(Av, DF, Fv)
+        @test length(Cv) == Nout
+
+        # manual decimated-correlation reference (0-indexed n, p)
+        Cref = Vector{Complex{T}}(undef, Nout)
+        for n in 0:(Nout - 1)
+            s = Complex{T}(0)
+            for p in 0:(P - 1)
+                s += Av[n * DF + p + 1] * Fv[p + 1]
+            end
+            Cref[n + 1] = s
+        end
+        @test Cv ≈ Cref rtol=rtol
+
+        Cout = Vector{Complex{T}}(undef, Nout)
+        AppleAccelerate.zrdesamp!(Cout, Av, DF, Fv)
+        @test Cout ≈ Cref rtol=rtol
+
+        # DF=1 (pure FIR correlation, no decimation)
+        C1 = AppleAccelerate.zrdesamp(Av, 1, Fv)
+        Nout1 = div(length(Av) - P, 1) + 1
+        Cref1 = Vector{Complex{T}}(undef, Nout1)
+        for n in 0:(Nout1 - 1)
+            s = Complex{T}(0)
+            for p in 0:(P - 1)
+                s += Av[n * 1 + p + 1] * Fv[p + 1]
+            end
+            Cref1[n + 1] = s
+        end
+        @test C1 ≈ Cref1 rtol=rtol
+
+        # errors when filter longer than signal
+        Ashort = complex.(randn(T, 3), randn(T, 3))
+        Flong = randn(T, 5)
+        @test_throws ErrorException AppleAccelerate.zrdesamp(Ashort, 1, Flong)
+        Coutbad = Vector{Complex{T}}(undef, 10)
+        @test_throws ErrorException AppleAccelerate.zrdesamp!(Coutbad, Ashort, 1, Flong)
+    end
+end
+
 end # @testset


### PR DESCRIPTION
Completes the vDSP split-complex matrix-multiply / resample family in `complexarray.jl`, building on the `zmma`/`zmms` added in #194.

## New wrappers (Float32 + Float64, allocating + `!` mutating)
- **`zmsm`/`zmsm!`** — complex matrix multiply and reverse-subtract: `D = C − A*B`.
- **`zvmmaa`/`zvmmaa!`** — elementwise vector multiply-multiply-add-add: `F = A*B + C*D + E`.
- **`zrdesamp`/`zrdesamp!`** — complex-real decimating resample/correlation.

## Notable: `zmsm` corrects #194's omission
#194 intentionally skipped `zmsm` on the belief it computes `(A−B)*C`, which doesn't compose under the col-major→row-major transpose swap. Empirical probing of the raw symbol shows `vDSP_zmsm` actually computes **`D = C − A*B`** (the vDSP.h header labels it "matrix multiply and reverse subtract"). That decomposes into an elementwise term (`C`) plus a matrix product (`A*B`), both of which transpose consistently under the same convention `zmmul`/`zmma` already use — so it composes cleanly with **no extra copy**.

Also note `zrdesamp` takes **no stride argument** (vDSP.h: "arrays map directly to memory"), so it can't use this file's interleaved-`_split_view` pointer trick — it deinterleaves into genuine contiguous real/imag buffers (à la `ctoz`/`ztoc`). Feeding it interleaved storage silently produces wrong results (verified).

## Tests
Cross-validated against Julia-native complex ops (`A*B .± C`, `C .- A*B`, elementwise, manual decimated correlation) for both Float32 (`rtol=sqrt(eps)`) and Float64, with non-square/non-symmetric inputs and `DimensionMismatch` guards. Full suite green (`Complex Array Operations (Batch 5)`: 270/270).

Wrappers cleared the FFI/GC hazard checklist: all operands `GC.@preserve`d across the ccall, length/shape guards before every call, operand order confirmed from the raw signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2BF1smS9ip9uAqb8cTqW3