### PR TITLE
array: zero-copy path for packed 24-bit conversions (follow-up to #197)

### DIFF
--- a/docs/src/array.md
+++ b/docs/src/array.md
@@ -558,6 +558,17 @@ packing/unpacking around each call.
 | [`vsmfix24`](@ref AppleAccelerate.vsmfix24) | `Float32` scaled by `b`, truncated to packed 24-bit signed int |
 | [`vsmfixu24`](@ref AppleAccelerate.vsmfixu24) | `Float32` scaled by `b`, truncated to packed 24-bit unsigned int |
 
+### Zero-copy packed interop
+
+When the data is already in Apple's packed 3-byte layout (e.g. 24-bit audio off
+disk or the wire), skip the per-call pack/unpack: the element types
+[`PackedInt24`](@ref AppleAccelerate.PackedInt24) / [`PackedUInt24`](@ref AppleAccelerate.PackedUInt24)
+can be handed straight to the conversions. Build a packed vector with
+[`pack24`](@ref AppleAccelerate.pack24) / [`packu24`](@ref AppleAccelerate.packu24)
+(or `reinterpret(PackedInt24, bytes)` over a raw `Vector{UInt8}`), pass it to the
+`vflt*24` functions (or write into it from `vsmfix*24!`), and decode with
+[`unpack24`](@ref AppleAccelerate.unpack24).
+
 ```@docs
 AppleAccelerate.vflt24
 AppleAccelerate.vfltu24
@@ -565,6 +576,11 @@ AppleAccelerate.vfltsm24
 AppleAccelerate.vfltsmu24
 AppleAccelerate.vsmfix24
 AppleAccelerate.vsmfixu24
+AppleAccelerate.PackedInt24
+AppleAccelerate.PackedUInt24
+AppleAccelerate.pack24
+AppleAccelerate.packu24
+AppleAccelerate.unpack24
 ```
 
 ## Type Conversion (int ↔ float)

--- a/src/array.jl
+++ b/src/array.jl
@@ -2230,6 +2230,105 @@ vsmfixu24(A::StridedVector{Float32}, b::Float32) = vsmfixu24!(Vector{UInt32}(und
 @doc "Scale `A` by `b` and truncate to packed 24-bit signed integers (returned as `Int32`): `C[i] = trunc(Int32, A[i] * b)`. Wraps [`vDSP_vsmfix24`](https://developer.apple.com/documentation/accelerate/vdsp_vsmfix24)." vsmfix24
 @doc "Scale `A` by `b` and truncate to packed 24-bit unsigned integers (returned as `UInt32`): `C[i] = trunc(UInt32, A[i] * b)`. Wraps [`vDSP_vsmfixu24`](https://developer.apple.com/documentation/accelerate/vdsp_vsmfixu24)." vsmfixu24
 
+# --- Zero-copy packed 24-bit interop ---
+#
+# The `vflt*24` / `vsmfix*24` wrappers above take/return ordinary integer vectors
+# and pack/unpack around each call — convenient, but an O(n) copy. When the data
+# is ALREADY in Apple's packed 3-byte layout (e.g. 24-bit audio as it comes off
+# disk or the wire), the variants below hand the packed buffer straight to vDSP
+# with no repacking. The packed element type is exposed as `PackedInt24` /
+# `PackedUInt24`; build one from an integer vector with [`pack24`](@ref) /
+# [`packu24`](@ref) and recover integers with [`unpack24`](@ref). A raw
+# `Vector{UInt8}` of `3n` bytes reinterprets to a packed vector zero-copy via
+# `reinterpret(PackedInt24, bytes)`.
+const PackedInt24  = LibAccelerate.vDSP_int24
+const PackedUInt24 = LibAccelerate.vDSP_uint24
+
+"""
+    pack24(A::AbstractVector{<:Integer}) -> Vector{PackedInt24}
+
+Pack integer values in `-8388608:8388607` into Apple's 3-byte signed 24-bit
+layout, ready to pass to [`vflt24`](@ref) / [`vfltsm24`](@ref) with no further
+copying. See also [`unpack24`](@ref), [`packu24`](@ref).
+"""
+pack24(A::AbstractVector{<:Integer}) = PackedInt24[_pack_int24(x) for x in A]
+
+"""
+    packu24(A::AbstractVector{<:Integer}) -> Vector{PackedUInt24}
+
+Pack integer values in `0:16777215` into Apple's 3-byte unsigned 24-bit layout.
+See also [`unpack24`](@ref), [`pack24`](@ref).
+"""
+packu24(A::AbstractVector{<:Integer}) = PackedUInt24[_pack_uint24(x) for x in A]
+
+"""
+    unpack24(A::AbstractVector{PackedInt24})  -> Vector{Int32}
+    unpack24(A::AbstractVector{PackedUInt24}) -> Vector{UInt32}
+
+Decode packed 24-bit integers back to `Int32` / `UInt32` values. Inverse of
+[`pack24`](@ref) / [`packu24`](@ref).
+"""
+unpack24(A::AbstractVector{PackedInt24})  = Int32[_unpack_int24(v)  for v in A]
+unpack24(A::AbstractVector{PackedUInt24}) = UInt32[_unpack_uint24(v) for v in A]
+
+# Zero-copy INPUT: hand an already-packed vector straight to vDSP (accepts strided
+# views and `reinterpret(PackedInt24, ::Vector{UInt8})` byte blobs).
+function vflt24!(C::StridedVector{Float32}, A::StridedVector{PackedInt24})
+    n = length(A)
+    length(C) >= n ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($n)"))
+    GC.@preserve A C LibAccelerate.vDSP_vflt24(pointer(A), stride(A,1), pointer(C), stride(C,1), n)
+    return C
+end
+vflt24(A::StridedVector{PackedInt24}) = vflt24!(Vector{Float32}(undef, length(A)), A)
+
+function vfltu24!(C::StridedVector{Float32}, A::StridedVector{PackedUInt24})
+    n = length(A)
+    length(C) >= n ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($n)"))
+    GC.@preserve A C LibAccelerate.vDSP_vfltu24(pointer(A), stride(A,1), pointer(C), stride(C,1), n)
+    return C
+end
+vfltu24(A::StridedVector{PackedUInt24}) = vfltu24!(Vector{Float32}(undef, length(A)), A)
+
+function vfltsm24!(C::StridedVector{Float32}, A::StridedVector{PackedInt24}, b::Float32)
+    n = length(A)
+    length(C) >= n ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($n)"))
+    GC.@preserve A C LibAccelerate.vDSP_vfltsm24(pointer(A), stride(A,1), Ref(b), pointer(C), stride(C,1), n)
+    return C
+end
+vfltsm24(A::StridedVector{PackedInt24}, b::Float32) = vfltsm24!(Vector{Float32}(undef, length(A)), A, b)
+
+function vfltsmu24!(C::StridedVector{Float32}, A::StridedVector{PackedUInt24}, b::Float32)
+    n = length(A)
+    length(C) >= n ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($n)"))
+    GC.@preserve A C LibAccelerate.vDSP_vfltsmu24(pointer(A), stride(A,1), Ref(b), pointer(C), stride(C,1), n)
+    return C
+end
+vfltsmu24(A::StridedVector{PackedUInt24}, b::Float32) = vfltsmu24!(Vector{Float32}(undef, length(A)), A, b)
+
+# Zero-copy OUTPUT: write vDSP's packed result straight into a packed vector.
+function vsmfix24!(C::StridedVector{PackedInt24}, A::StridedVector{Float32}, b::Float32)
+    n = length(A)
+    length(C) >= n ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($n)"))
+    GC.@preserve A C LibAccelerate.vDSP_vsmfix24(pointer(A), stride(A,1), Ref(b), pointer(C), stride(C,1), n)
+    return C
+end
+
+function vsmfixu24!(C::StridedVector{PackedUInt24}, A::StridedVector{Float32}, b::Float32)
+    n = length(A)
+    length(C) >= n ||
+        throw(DimensionMismatch("C length ($(length(C))) must be at least length(A) ($n)"))
+    GC.@preserve A C LibAccelerate.vDSP_vsmfixu24(pointer(A), stride(A,1), Ref(b), pointer(C), stride(C,1), n)
+    return C
+end
+
+@doc "Packed 24-bit signed integer element (Apple's 3-byte `vDSP_int24`). Build a vector with [`pack24`](@ref); decode with [`unpack24`](@ref)." PackedInt24
+@doc "Packed 24-bit unsigned integer element (Apple's 3-byte `vDSP_uint24`). Build a vector with [`packu24`](@ref); decode with [`unpack24`](@ref)." PackedUInt24
+
 # --- Integer vector ops ---
 function vdivi!(C::StridedVector{Cint}, A::StridedVector{Cint}, B::StridedVector{Cint})
     length(A) == length(B) ||

--- a/test/array_tests.jl
+++ b/test/array_tests.jl
@@ -1843,6 +1843,51 @@ end
     @test_throws DimensionMismatch AppleAccelerate.vflt24!(Vector{Float32}(undef, 1), A)
 end
 
+@testset "24-bit zero-copy packed interop" begin
+    AA = AppleAccelerate
+    vals = Int32[8388607, -8388608, 0, 12345, -12345]
+
+    # pack / unpack round-trip
+    packed = AA.pack24(vals)
+    @test packed isa Vector{AA.PackedInt24}
+    @test AA.unpack24(packed) == vals
+
+    # zero-copy conversion on a packed vector matches the integer-vector path
+    @test AA.vflt24(packed) ≈ AA.vflt24(vals) ≈ Float32.(vals)
+
+    # a raw byte blob (3n bytes) reinterprets to a packed vector zero-copy
+    bytes = collect(reinterpret(UInt8, packed))
+    @test length(bytes) == 3 * length(vals)
+    @test AA.vflt24(reinterpret(AA.PackedInt24, bytes)) ≈ Float32.(vals)
+
+    # unsigned
+    uvals = UInt32[16777215, 0, 12345]
+    upk = AA.packu24(uvals)
+    @test upk isa Vector{AA.PackedUInt24}
+    @test AA.unpack24(upk) == uvals
+    @test AA.vfltu24(upk) ≈ AA.vfltu24(uvals) ≈ Float32.(uvals)
+
+    # scaled input variants
+    b = 2.0f0
+    @test AA.vfltsm24(packed, b) ≈ Float32.(vals) .* b
+    @test AA.vfltsmu24(upk, b) ≈ Float32.(uvals) .* b
+
+    # zero-copy OUTPUT: write vDSP's packed result straight into a packed vector
+    Af = Float32[1.5, -2.25, 100.0, -100.9]
+    outp = Vector{AA.PackedInt24}(undef, length(Af))
+    @test AA.vsmfix24!(outp, Af, 1.0f0) === outp
+    @test AA.unpack24(outp) == Int32.(trunc.(Af))
+
+    Afu = Float32[1.9, 2.25, 100.0]
+    outu = Vector{AA.PackedUInt24}(undef, length(Afu))
+    AA.vsmfixu24!(outu, Afu, 1.0f0)
+    @test AA.unpack24(outu) == UInt32.(trunc.(Afu))
+
+    # length guards on the zero-copy paths
+    @test_throws DimensionMismatch AA.vflt24!(Vector{Float32}(undef, 1), packed)
+    @test_throws DimensionMismatch AA.vsmfix24!(Vector{AA.PackedInt24}(undef, 1), Af, 1.0f0)
+end
+
 @testset "Integer vector ops: vdivi, vsaddi, vsdivi" begin
     A = Int32[10, 20, 33, -40, 51]
     Bv = Int32[2, 5, 3, -8, 7]


### PR DESCRIPTION
Follow-up to #197. The `vflt*24` / `vsmfix*24` wrappers currently take/return ordinary integer vectors and pack/unpack around **every call** — an O(n) copy that defeats the purpose of the 24-bit format when the data is *already* in Apple's packed 3-byte layout (e.g. 24-bit audio as it comes off disk or the wire; a user with packed bytes otherwise has to unpack to `Int32` just so the wrapper can repack).

This adds a zero-copy path alongside the existing convenience API (which is unchanged and remains the default — purely additive).

## New API
- **Interop aliases** `PackedInt24` / `PackedUInt24` (Apple's 3-byte `vDSP_int24`/`vDSP_uint24`), so users never touch the raw `LibAccelerate.*` type.
- **`pack24`/`packu24`** (Integer vector → packed vector) and **`unpack24`** (packed → `Int32`/`UInt32`).
- **Zero-copy INPUT:** `vflt24`/`vfltu24`/`vfltsm24`/`vfltsmu24` methods on `StridedVector{Packed*24}` — hand the packed buffer straight to vDSP with no repack. Accepts strided views and `reinterpret(PackedInt24, ::Vector{UInt8})` byte blobs.
- **Zero-copy OUTPUT:** `vsmfix24!`/`vsmfixu24!` writing into a `StridedVector{Packed*24}`, no unpack.

## Design note
Deliberately **not** a numeric `Int24 <: Integer` type — packed 24-bit is a storage/interop format, not something you compute in (no promotion/arithmetic/printing surface). This follows the general principle for packed formats: thin `reinterpret`-friendly byte-tuple types with explicit pack/unpack + a zero-copy path, never numeric types. (Same rule will carry to vImage's packed pixel formats.)

## Tests & docs
Zero-copy results cross-validated against the integer-vector path and Base for both packed input and output, including the byte-blob `reinterpret` case and length guards. `Array Operations` 1117/1117; docs build clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2BF1smS9ip9uAqb8cTqW3