### PR TITLE
sparse: complex (ComplexF32/ComplexF64) support across the full solver surface

### DIFF
--- a/docs/src/sparse.md
+++ b/docs/src/sparse.md
@@ -35,9 +35,10 @@ B = AASparseMatrix(I, J, V, 3, 3)
 nothing # hide
 ```
 
-The `SparseMatrixCSC` constructor automatically detects symmetric and triangular
-structure and sets the appropriate Apple Accelerate attributes. The COO constructor
-uses Accelerate's `SparseConvertFromCoordinate` and accepts `Float32`/`Float64` values.
+The `SparseMatrixCSC` constructor automatically detects symmetric/Hermitian and
+triangular structure and sets the appropriate Apple Accelerate attributes. The COO
+constructor uses Accelerate's `SparseConvertFromCoordinate` and accepts
+`Float32`/`Float64` and (macOS 15.5+) `ComplexF32`/`ComplexF64` values.
 
 ### Matrix operations
 
@@ -48,6 +49,7 @@ uses Accelerate's `SparseConvertFromCoordinate` and accepts `Float32`/`Float64` 
 | `alpha * A * x` | Scaled sparse multiply |
 | [`muladd!`](@ref AppleAccelerate.muladd!) | Multiply-add: `y += A * x` or `y += alpha * A * x` |
 | `transpose(A)` | Transpose (sets flag, no copy) |
+| `adjoint(A)` / `A'` | Conjugate transpose (complex; equals `transpose` for real) |
 
 ### Query functions
 
@@ -59,6 +61,37 @@ uses Accelerate's `SparseConvertFromCoordinate` and accepts `Float32`/`Float64` 
 | `istriu(A)` | Check if upper triangular |
 | `istril(A)` | Check if lower triangular |
 | `A[i, j]` | Element access |
+
+## Complex-valued matrices
+
+The **entire** sparse surface accepts `ComplexF32`/`ComplexF64` in addition to
+`Float32`/`Float64` (complex requires **macOS 15.5+**): the `SparseMatrixCSC` and
+COO constructors, direct factorizations (Cholesky/LDLᵀ/LU/QR), `solve`/`solve!`/
+`ldiv!`, `refactor!`, `SparseMultiply`/`muladd!`, transpose/adjoint, the iterative
+solvers (`:cg`/`:gmres`/`:lsmr`) with preconditioners, sub-factor extraction, the
+preallocated-workspace solve, partial-LU update, and introspection.
+
+Complex matrices differ from real ones in two ways:
+
+  - **Cholesky and CG use the Hermitian path.** For a complex matrix, `cholesky(A)`
+    and `solve(A, b; method = :cg)` require `A` to be **Hermitian** positive-definite
+    (`A == A'`), and dispatch to libSparse's Hermitian factorization — not the
+    (complex-)symmetric one. A `SparseMatrixCSC{Complex}` that satisfies `ishermitian`
+    is auto-tagged Hermitian when wrapped.
+  - **`adjoint` (`A'`) and `transpose` are distinct.** `adjoint` conjugates as well as
+    transposes; both are attribute-flag views that share the underlying CSC data.
+
+```@example sparse_complex
+using AppleAccelerate, SparseArrays, LinearAlgebra
+import AppleAccelerate: AASparseMatrix, cholesky, solve
+
+M = sprandn(ComplexF64, 60, 60, 0.05)
+H = AASparseMatrix(SparseMatrixCSC(M * M' + 60I))   # Hermitian positive-definite
+b = randn(ComplexF64, 60)
+x = solve(cholesky(H), b)                            # Hermitian Cholesky
+@assert x ≈ Matrix(H) \ b
+nothing # hide
+```
 
 ## AAFactorization
 

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -553,6 +553,23 @@ end
     SparseMatrix,
     Cint, Cint, Clong, Cuchar, att_type, Ptr{Cint}, Ptr{Cint}, Ptr, Ptr{Cvoid}, Ptr{Cvoid})
 
+# complex COO->CSC workspace variants (macOS 15.5+). The library mangles the
+# complex value pointer as C `float _Complex`/`double _Complex` (`PKCf`/`PKCd`),
+# which adds one substitution vs the real symbols, so the trailing void* reuses
+# `S5_` (not `S4_`). The attribute struct is still the plain `SparseAttributes_t`
+# (18); its 3-bit Hermitian kind field fits the same 32-bit word.
+@generateDemangled(SparseConvertFromCoord,
+    :_Z27SparseConvertFromCoordinateiilh18SparseAttributes_tPKiS1_PKCfPvS5_,
+    ComplexF32,
+    SparseMatrix,
+    Cint, Cint, Clong, Cuchar, att_type, Ptr{Cint}, Ptr{Cint}, Ptr, Ptr{Cvoid}, Ptr{Cvoid})
+
+@generateDemangled(SparseConvertFromCoord,
+    :_Z27SparseConvertFromCoordinateiilh18SparseAttributes_tPKiS1_PKCdPvS5_,
+    ComplexF64,
+    SparseMatrix,
+    Cint, Cint, Clong, Cuchar, att_type, Ptr{Cint}, Ptr{Cint}, Ptr, Ptr{Cvoid}, Ptr{Cvoid})
+
 # cleanup SparseMatrix
 @generateDemangled(SparseCleanup,
     :_Z13SparseCleanup18SparseMatrix_Float,
@@ -882,12 +899,14 @@ value at row `I[k]`, column `J[k]`, with 1-based indices as in
 sorted internally) and duplicate coordinates are summed. Uses Accelerate's
 [`SparseConvertFromCoordinate`](https://developer.apple.com/documentation/accelerate/sparseconvertfromcoordinate).
 
-`V` must be `Float32` or `Float64`. Pass `attributes` (e.g. `ATT_SYMMETRIC | ATT_LOWER_TRIANGLE`)
-to build a matrix with symmetry/triangle structure; Accelerate coerces the input to conform.
+`V` must be `Float32`, `Float64`, `ComplexF32`, or `ComplexF64` (complex requires
+macOS 15.5+). Pass `attributes` (e.g. `ATT_SYMMETRIC | ATT_LOWER_TRIANGLE`, or
+`ATT_HERMITIAN | ATT_LOWER_TRIANGLE` for complex) to build a matrix with
+symmetry/triangle structure; Accelerate coerces the input to conform.
 """
 function AASparseMatrix(I::AbstractVector{<:Integer}, J::AbstractVector{<:Integer},
                         V::AbstractVector{T}, m::Integer, n::Integer,
-                        attributes::att_type = ATT_ORDINARY) where T<:Union{Cfloat,Cdouble}
+                        attributes::att_type = ATT_ORDINARY) where T<:vTypes
     length(I) == length(J) == length(V) ||
         throw(DimensionMismatch("I, J, and V must have equal lengths " *
                                 "($(length(I)), $(length(J)), $(length(V)))"))
@@ -1616,7 +1635,9 @@ const SparsePreconditionerDiagonal   = SparsePreconditioner_t(2)
 const SparsePreconditionerDiagScaling = SparsePreconditioner_t(3)
 
 # Layout mirrors libSparse's SparseOpaquePreconditioner_* (type, mem, apply).
-struct SparseOpaquePreconditioner{T<:Union{Float32,Float64}}
+# All fields are pointers/ints, so the layout is identical for real and complex T
+# (T is a phantom used only for dispatch).
+struct SparseOpaquePreconditioner{T<:vTypes}
     type::SparsePreconditioner_t
     mem::Ptr{Cvoid}
     apply::Ptr{Cvoid}
@@ -1625,18 +1646,22 @@ end
 """Opaque preconditioner handle for the iterative solvers. Build with
 [`AAPreconditioner`](@ref). Wraps a libSparse `SparseOpaquePreconditioner`; the
 backing memory is released by a finalizer."""
-mutable struct AAPreconditioner{T<:Union{Float32,Float64}}
+mutable struct AAPreconditioner{T<:vTypes}
     _p::SparseOpaquePreconditioner{T}
     _matrix::AASparseMatrix{T}   # keep the source matrix rooted for the handle's life
 end
 
 const _PRECOND_CREATE = Dict(
-    Cfloat  => :_SparseCreatePreconditioner_Float,
-    Cdouble => :_SparseCreatePreconditioner_Double,
+    Cfloat     => :_SparseCreatePreconditioner_Float,
+    Cdouble    => :_SparseCreatePreconditioner_Double,
+    ComplexF32 => :_SparseCreatePreconditioner_Complex_Float,
+    ComplexF64 => :_SparseCreatePreconditioner_Complex_Double,
 )
 const _PRECOND_RELEASE = Dict(
-    Cfloat  => :_SparseReleaseOpaquePreconditioner_Float,
-    Cdouble => :_SparseReleaseOpaquePreconditioner_Double,
+    Cfloat     => :_SparseReleaseOpaquePreconditioner_Float,
+    Cdouble    => :_SparseReleaseOpaquePreconditioner_Double,
+    ComplexF32 => :_SparseReleaseOpaquePreconditioner_Complex_Float,
+    ComplexF64 => :_SparseReleaseOpaquePreconditioner_Complex_Double,
 )
 
 function _precond_symbol(p::Symbol)
@@ -1676,9 +1701,9 @@ end
 
 Construct a preconditioner for `A` to accelerate the iterative solvers
 ([`solve`](@ref) with a `method` keyword). `kind` is `:diagonal` (Jacobi) or
-`:diagscaling`. Real `Float32`/`Float64` only.
+`:diagscaling`. `Float32`/`Float64`, and (macOS 15.5+) `ComplexF32`/`ComplexF64`.
 """
-function AAPreconditioner(A::AASparseMatrix{T}; kind::Symbol = :diagonal) where {T<:Union{Float32,Float64}}
+function AAPreconditioner(A::AASparseMatrix{T}; kind::Symbol = :diagonal) where {T<:vTypes}
     return _create_preconditioner(_precond_symbol(kind), A)
 end
 
@@ -1700,6 +1725,16 @@ const _ITER_SOLVE_SYMS = Dict(
         :_Z11SparseSolve21SparseIterativeMethod19SparseMatrix_Double18DenseMatrix_DoubleS1_,
         :_Z11SparseSolve21SparseIterativeMethod19SparseMatrix_Double18DenseMatrix_DoubleS1_i,
         :_Z11SparseSolve21SparseIterativeMethod19SparseMatrix_Double18DenseMatrix_DoubleS1_33SparseOpaquePreconditioner_Double),
+    # complex variants (macOS 15.5+). CG requires a Hermitian(-positive-definite)
+    # matrix; GMRES/LSMR are general.
+    ComplexF32 => (
+        :_Z11SparseSolve21SparseIterativeMethod26SparseMatrix_Complex_Float25DenseMatrix_Complex_FloatS1_,
+        :_Z11SparseSolve21SparseIterativeMethod26SparseMatrix_Complex_Float25DenseMatrix_Complex_FloatS1_i,
+        :_Z11SparseSolve21SparseIterativeMethod26SparseMatrix_Complex_Float25DenseMatrix_Complex_FloatS1_40SparseOpaquePreconditioner_Complex_Float),
+    ComplexF64 => (
+        :_Z11SparseSolve21SparseIterativeMethod27SparseMatrix_Complex_Double26DenseMatrix_Complex_DoubleS1_,
+        :_Z11SparseSolve21SparseIterativeMethod27SparseMatrix_Complex_Double26DenseMatrix_Complex_DoubleS1_i,
+        :_Z11SparseSolve21SparseIterativeMethod27SparseMatrix_Complex_Double26DenseMatrix_Complex_DoubleS1_41SparseOpaquePreconditioner_Complex_Double),
 )
 for (T, (base, enumsym, opaquesym)) in _ITER_SOLVE_SYMS
     @eval _iter_solve!(m::SparseIterativeMethod, A::SparseMatrix{$T},
@@ -1745,14 +1780,16 @@ factorization, returning `x`. `method` (required) is one of:
 `atol`/`rtol` are the absolute/relative convergence tolerances (0 selects the
 library default), `maxiter` the iteration cap (0 → 100). `preconditioner` may be
 `:none`, `:diagonal`, `:diagscaling`, or an [`AAPreconditioner`](@ref). `b` may
-be a vector or a matrix (multiple right-hand sides). Real `Float32`/`Float64`.
+be a vector or a matrix (multiple right-hand sides). `Float32`/`Float64`, and
+(macOS 15.5+) `ComplexF32`/`ComplexF64` — for complex, `:cg` requires a Hermitian
+positive-definite matrix.
 """
 function solve(A::AASparseMatrix{T}, b::StridedVecOrMat{T};
                method::Symbol,
                preconditioner::Union{Symbol,AAPreconditioner} = :none,
                atol::Real = 0, rtol::Real = 0, maxiter::Integer = 0,
                nvec::Integer = 0, variant::Symbol = :dqgmres,
-               lambda::Real = 0) where {T<:Union{Float32,Float64}}
+               lambda::Real = 0) where {T<:vTypes}
     m, n = size(A)
     size(b, 1) == m || throw(DimensionMismatch(
         "right-hand side has $(size(b, 1)) rows; A has $m rows"))
@@ -1788,7 +1825,7 @@ function solve(A::AASparseMatrix{T}, b::StridedVecOrMat{T};
     return b isa AbstractVector ? vec(X) : X
 end
 
-solve(A::SparseMatrixCSC{T,Int64}, b::StridedVecOrMat{T}; kw...) where {T<:Union{Float32,Float64}} =
+solve(A::SparseMatrixCSC{T,Int64}, b::StridedVecOrMat{T}; kw...) where {T<:vTypes} =
     solve(AASparseMatrix(A), b; kw...)
 
 # ============================================================
@@ -1804,6 +1841,11 @@ const _SOLVE_WS_SYMS = Dict(
                 :_Z11SparseSolve31SparseOpaqueFactorization_Float17DenseMatrix_FloatPv),
     Cdouble => (:_Z11SparseSolve32SparseOpaqueFactorization_Double18DenseMatrix_DoubleS0_Pv,
                 :_Z11SparseSolve32SparseOpaqueFactorization_Double18DenseMatrix_DoublePv),
+    # complex variants (macOS 15.5+)
+    ComplexF32 => (:_Z11SparseSolve39SparseOpaqueFactorization_Complex_Float25DenseMatrix_Complex_FloatS0_Pv,
+                   :_Z11SparseSolve39SparseOpaqueFactorization_Complex_Float25DenseMatrix_Complex_FloatPv),
+    ComplexF64 => (:_Z11SparseSolve40SparseOpaqueFactorization_Complex_Double26DenseMatrix_Complex_DoubleS0_Pv,
+                   :_Z11SparseSolve40SparseOpaqueFactorization_Complex_Double26DenseMatrix_Complex_DoublePv),
 )
 for (T, (outsym, insym)) in _SOLVE_WS_SYMS
     @eval _solve_ws!(f::SparseOpaqueFactorization{$T}, B::StridedMatrix{$T},
@@ -1846,7 +1888,7 @@ In-place variant: `xb` holds the right-hand side on input and the solution on
 output (square systems only).
 """
 function solve!(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T},
-                x::StridedVecOrMat{T}, workspace::Vector{UInt8}) where {T<:Union{Float32,Float64}}
+                x::StridedVecOrMat{T}, workspace::Vector{UInt8}) where {T<:vTypes}
     m, n = size(aa_fact.matrixObj)
     size(b, 1) == m || throw(DimensionMismatch("RHS has $(size(b,1)) rows; A has $m rows"))
     size(x, 1) == n || throw(DimensionMismatch("solution has $(size(x,1)) rows; A has $n cols"))
@@ -1863,7 +1905,7 @@ function solve!(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T},
 end
 
 function solve!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T},
-                workspace::Vector{UInt8}) where {T<:Union{Float32,Float64}}
+                workspace::Vector{UInt8}) where {T<:vTypes}
     m, n = size(aa_fact.matrixObj)
     m == n || throw(ArgumentError("in-place workspace solve requires a square system"))
     size(xb, 1) == n || throw(DimensionMismatch("RHS has $(size(xb,1)) rows; A is $m×$n"))
@@ -1894,8 +1936,9 @@ const SparseSubfactorR    = SparseSubfactor_t(7)
 const SparseSubfactorRP   = SparseSubfactor_t(8)
 
 # 128-byte layout: attributes@0, contents@4, factor@8, wsStatic@112, wsPerRHS@120
-# (verified against the raw layer).
-struct SparseOpaqueSubfactor{T<:Union{Float32,Float64}}
+# (verified against the raw layer). Layout is identical for real and complex T
+# (the embedded SparseOpaqueFactorization{T} has a phantom T, no T-typed field).
+struct SparseOpaqueSubfactor{T<:vTypes}
     attributes::att_type
     contents::SparseSubfactor_t
     factor::SparseOpaqueFactorization{T}
@@ -1907,14 +1950,16 @@ end
 [`AAFactorization`](@ref), created with [`subfactor`](@ref). Holds a *borrowed*
 reference into its parent factorization (kept alive by this object), so it needs
 no separate release. Apply it with `*` (multiply) or `\\` (solve)."""
-mutable struct AASubfactor{T<:Union{Float32,Float64}}
+mutable struct AASubfactor{T<:vTypes}
     _sub::SparseOpaqueSubfactor{T}
     _parent::AAFactorization{T}
 end
 
 const _SUBF_WS_SYMS = Dict(
-    Cfloat  => :_SparseGetWorkspaceRequired_Float,
-    Cdouble => :_SparseGetWorkspaceRequired_Double,
+    Cfloat     => :_SparseGetWorkspaceRequired_Float,
+    Cdouble    => :_SparseGetWorkspaceRequired_Double,
+    ComplexF32 => :_SparseGetWorkspaceRequired_Complex_Float,
+    ComplexF64 => :_SparseGetWorkspaceRequired_Complex_Double,
 )
 for (T, sym) in _SUBF_WS_SYMS
     @eval function _subfactor_ws(contents::SparseSubfactor_t, f::SparseOpaqueFactorization{$T})
@@ -1941,9 +1986,10 @@ Extract an individual factor of the factorization `f` for direct application.
 `SparseSubfactorQ`/`SparseSubfactorR` (from QR),
 `SparseSubfactorL`/`SparseSubfactorD`/`SparseSubfactorP` (from Cholesky/LDLᵀ).
 `f` is factored if necessary. Apply the result with `sub * x` (multiply by the
-factor) or `sub \\ b` (solve against it). Real `Float32`/`Float64` only.
+factor) or `sub \\ b` (solve against it). `Float32`/`Float64`, and (macOS 15.5+)
+`ComplexF32`/`ComplexF64`.
 """
-function subfactor(f::AAFactorization{T}, which::SparseSubfactor_t) where {T<:Union{Float32,Float64}}
+function subfactor(f::AAFactorization{T}, which::SparseSubfactor_t) where {T<:vTypes}
     factor!(f)
     fac = f._factorization
     fac.status == SparseStatusOk ||
@@ -1960,6 +2006,11 @@ const _SUBF_APPLY_SYMS = Dict(
                 :_Z11SparseSolve27SparseOpaqueSubfactor_Float17DenseMatrix_FloatS0_),
     Cdouble => (:_Z14SparseMultiply28SparseOpaqueSubfactor_Double18DenseMatrix_DoubleS0_,
                 :_Z11SparseSolve28SparseOpaqueSubfactor_Double18DenseMatrix_DoubleS0_),
+    # complex variants (macOS 15.5+)
+    ComplexF32 => (:_Z14SparseMultiply35SparseOpaqueSubfactor_Complex_Float25DenseMatrix_Complex_FloatS0_,
+                   :_Z11SparseSolve35SparseOpaqueSubfactor_Complex_Float25DenseMatrix_Complex_FloatS0_),
+    ComplexF64 => (:_Z14SparseMultiply36SparseOpaqueSubfactor_Complex_Double26DenseMatrix_Complex_DoubleS0_,
+                   :_Z11SparseSolve36SparseOpaqueSubfactor_Complex_Double26DenseMatrix_Complex_DoubleS0_),
 )
 for (T, (mulsym, solvesym)) in _SUBF_APPLY_SYMS
     @eval _subfactor_mul!(s::SparseOpaqueSubfactor{$T}, X::StridedMatrix{$T}, Y::StridedMatrix{$T}) =
@@ -1993,7 +2044,7 @@ Multiply the vector/matrix `x` by the extracted sub-factor `sub` (e.g. form
 `Q*x`). If `sub` acts as an `m×n` operator, `x` must have `n` rows and the
 result has `m` rows.
 """
-function Base.:(*)(sub::AASubfactor{T}, x::StridedVecOrMat{T}) where {T<:Union{Float32,Float64}}
+function Base.:(*)(sub::AASubfactor{T}, x::StridedVecOrMat{T}) where {T<:vTypes}
     m, n = _subfactor_dimn(sub._sub)
     size(x, 1) == n || throw(DimensionMismatch(
         "sub-factor multiply expects $(n) rows; got $(size(x, 1))"))
@@ -2011,7 +2062,7 @@ Solve a system against the extracted sub-factor `sub` (e.g. triangular solve
 `R \\ b`, or apply `Qᵀ` via `Q \\ b`). If `sub` acts as an `m×n` operator, `b`
 must have `m` rows and the result has `n` rows.
 """
-function Base.:(\)(sub::AASubfactor{T}, b::StridedVecOrMat{T}) where {T<:Union{Float32,Float64}}
+function Base.:(\)(sub::AASubfactor{T}, b::StridedVecOrMat{T}) where {T<:vTypes}
     m, n = _subfactor_dimn(sub._sub)
     size(b, 1) == m || throw(DimensionMismatch(
         "sub-factor solve expects $(m) rows; got $(size(b, 1))"))
@@ -2030,8 +2081,10 @@ end
 # entries. Requires a *pivotless* LU factorization (LUUnpivoted/LUSPP/LUTPP).
 
 const _UPDATE_LU_SYMS = Dict(
-    Cfloat  => :_SparseUpdatePartialRefactorLU_Float,
-    Cdouble => :_SparseUpdatePartialRefactorLU_Double,
+    Cfloat     => :_SparseUpdatePartialRefactorLU_Float,
+    Cdouble    => :_SparseUpdatePartialRefactorLU_Double,
+    ComplexF32 => :_SparseUpdatePartialRefactorLU_Complex_Float,
+    ComplexF64 => :_SparseUpdatePartialRefactorLU_Complex_Double,
 )
 for (T, sym) in _UPDATE_LU_SYMS
     @eval function _update_partial_lu!(fref::Base.RefValue{SparseOpaqueFactorization{$T}},
@@ -2059,15 +2112,15 @@ sparsity pattern** as the original.
 
 `f` must hold a **pivotless** LU factorization (`SparseFactorizationLUUnpivoted`,
 `SparseFactorizationLUSPP`, or `SparseFactorizationLUTPP`) — build it with
-`factor!(f, SparseFactorizationLUUnpivoted)`. Requires macOS 15.5+. Real
-`Float32`/`Float64` only. Returns `f`.
+`factor!(f, SparseFactorizationLUUnpivoted)`. Requires macOS 15.5+.
+`Float32`/`Float64`/`ComplexF32`/`ComplexF64`. Returns `f`.
 
 Distinct from [`refactor!`](@ref), which recomputes the entire numeric
 factorization.
 """
 function update_partial_lu!(f::AAFactorization{T},
         updated::AbstractVector{<:Tuple{Integer,Integer}},
-        A_new::AASparseMatrix{T}) where {T<:Union{Float32,Float64}}
+        A_new::AASparseMatrix{T}) where {T<:vTypes}
     fac = f._factorization
     fac.status == SparseStatusOk || throw(ArgumentError(
         "update_partial_lu! requires a completed factorization; call factor! first"))
@@ -2099,8 +2152,10 @@ end
 # ============================================================
 
 const _NUMOPTS_SYMS = Dict(
-    Cfloat  => :_SparseGetOptionsFromNumericFactor_Float,
-    Cdouble => :_SparseGetOptionsFromNumericFactor_Double,
+    Cfloat     => :_SparseGetOptionsFromNumericFactor_Float,
+    Cdouble    => :_SparseGetOptionsFromNumericFactor_Double,
+    ComplexF32 => :_SparseGetOptionsFromNumericFactor_Complex_Float,
+    ComplexF64 => :_SparseGetOptionsFromNumericFactor_Complex_Double,
 )
 for (T, sym) in _NUMOPTS_SYMS
     @eval function _numeric_options(f::SparseOpaqueFactorization{$T})
@@ -2117,9 +2172,9 @@ end
 
 Read back the numeric-factorization options (scaling method, pivot/zero
 tolerances) that libSparse recorded for the completed factorization `f`. `f`
-must already be factored. Real `Float32`/`Float64` only.
+must already be factored. `Float32`/`Float64`/`ComplexF32`/`ComplexF64`.
 """
-function numeric_options(f::AAFactorization{T}) where {T<:Union{Float32,Float64}}
+function numeric_options(f::AAFactorization{T}) where {T<:vTypes}
     f._factorization.status == SparseStatusOk || throw(ArgumentError(
         "numeric_options requires a completed factorization; call factor! first"))
     return _numeric_options(f._factorization)

--- a/test/sparse_tests.jl
+++ b/test/sparse_tests.jl
@@ -1222,4 +1222,177 @@ import AppleAccelerate: AAFactorization, AASparseMatrix, factor!, muladd!, refac
             @test_throws ArgumentError AppleAccelerate.numeric_options(f)   # not yet factored
         end
     end
+
+    # Complex sparse support across the extended solver surface (macOS 15.5+).
+    # Cross-validated against dense `\` / LinearAlgebra for both ComplexF32 and
+    # ComplexF64. CG/Cholesky use Hermitian-positive-definite matrices;
+    # GMRES/LU/LSMR use discriminating non-Hermitian matrices.
+    something(AppleAccelerate.get_macos_version(), v"0.0.0") >= v"15.5" &&
+    @testset "Complex extended surface" begin
+        AA = AppleAccelerate
+
+        # Build a Hermitian positive-definite complex sparse matrix.
+        hpd(::Type{T}, n) where {T} = begin
+            M = sprandn(T, n, n, 0.15)
+            A = M * M' + n * I
+            SparseMatrixCSC{T,Int64}((A + A') / 2)
+        end
+
+        @testset "COO constructor $T" for T in (ComplexF32, ComplexF64)
+            rtol = T == ComplexF32 ? sqrt(eps(Float32)) : 1e-9
+            ref = sprandn(T, 11, 8, 0.3)
+            I, J, V = findnz(ref)
+            A = AASparseMatrix(I, J, V, 11, 8)
+            @test Matrix(A) ≈ Matrix(ref)
+            x = randn(T, 8)
+            @test A * x ≈ Matrix(ref) * x rtol = rtol
+            # Duplicate coordinates are summed.
+            Ad = AASparseMatrix(Int[1, 1, 2], Int[1, 1, 2], T[1+im, 2-im, 5], 2, 2)
+            @test Matrix(Ad) ≈ T[3 0; 0 5]
+            # Unsorted triplets round-trip through SparseArrays.sparse.
+            Iu = [3, 1, 2, 3]; Ju = [3, 1, 2, 3]; Vu = T[7im, 10, 20, 3]  # (3,3): 7im+3
+            Au = AASparseMatrix(Iu, Ju, Vu, 3, 3)
+            @test SparseMatrixCSC(Au) ≈ sparse(Iu, Ju, Vu, 3, 3)
+        end
+
+        @testset "Hermitian Cholesky solve $T" for T in (ComplexF32, ComplexF64)
+            rtol = T == ComplexF32 ? 1e-3 : 1e-8
+            n = 24
+            Acsc = hpd(T, n)
+            Aaa = AASparseMatrix(Acsc)
+            @test ishermitian(Aaa)
+            b = randn(T, n)
+            xref = Matrix(Acsc) \ b
+            f = AA.cholesky(Aaa)          # dispatches to Hermitian factorization
+            @test isapprox(AA.solve(f, b), xref; rtol = rtol)
+            @test isapprox(f \ b, xref; rtol = rtol)
+        end
+
+        @testset "CG on Hermitian-PD $T" for T in (ComplexF32, ComplexF64)
+            rtol = T == ComplexF32 ? 1e-2 : 1e-6
+            n = 40
+            Acsc = hpd(T, n)
+            b = randn(T, n)
+            xref = Matrix(Acsc) \ b
+            x = AA.solve(AASparseMatrix(Acsc), b; method = :cg,
+                         rtol = T == ComplexF32 ? 1.0f-6 : 1e-11, maxiter = 5000)
+            @test isapprox(x, xref; rtol = rtol)
+            # Also accepts a SparseMatrixCSC directly.
+            @test isapprox(AA.solve(Acsc, b; method = :cg,
+                           rtol = T == ComplexF32 ? 1.0f-6 : 1e-11, maxiter = 5000),
+                           xref; rtol = rtol)
+            # Diagonal preconditioner also converges.
+            P = AA.AAPreconditioner(AASparseMatrix(Acsc); kind = :diagonal)
+            xp = AA.solve(AASparseMatrix(Acsc), b; method = :cg, preconditioner = P,
+                          rtol = T == ComplexF32 ? 1.0f-6 : 1e-11, maxiter = 5000)
+            @test isapprox(xp, xref; rtol = rtol)
+        end
+
+        @testset "LU + GMRES on non-Hermitian $T" for T in (ComplexF32, ComplexF64)
+            rtol = T == ComplexF32 ? 5e-2 : 1e-5
+            n = 30
+            A = sprandn(T, n, n, 0.15) + n * I     # square, non-Hermitian
+            @test A != A'                           # discriminating
+            Acsc = SparseMatrixCSC{T,Int64}(A)
+            Aaa = AASparseMatrix(Acsc)
+            b = randn(T, n)
+            xref = Matrix(Acsc) \ b
+            # Direct LU (default for square non-Hermitian on 15.5+).
+            f = AA.lu(Aaa)
+            @test isapprox(AA.solve(f, b), xref; rtol = T == ComplexF32 ? 1e-3 : 1e-9)
+            # GMRES.
+            xg = AA.solve(Aaa, b; method = :gmres, maxiter = 3000,
+                          rtol = T == ComplexF32 ? 1.0f-7 : 1e-12)
+            @test isapprox(xg, xref; rtol = rtol)
+        end
+
+        @testset "QR + LSMR on rectangular $T" for T in (ComplexF32, ComplexF64)
+            rtol = T == ComplexF32 ? 5e-2 : 1e-4
+            m, n = 48, 20
+            A = sprandn(T, m, n, 0.3)
+            while rank(Matrix(A)) < n
+                A = sprandn(T, m, n, 0.3)
+            end
+            Acsc = SparseMatrixCSC{T,Int64}(A)
+            Aaa = AASparseMatrix(Acsc)
+            b = randn(T, m)
+            xref = Matrix(Acsc) \ b                 # dense least-squares
+            f = AA.qr(Aaa)
+            @test isapprox(AA.solve(f, b), xref; rtol = T == ComplexF32 ? 1e-2 : 1e-7)
+            xl = AA.solve(Aaa, b; method = :lsmr, maxiter = 6000,
+                          rtol = T == ComplexF32 ? 1.0f-7 : 1e-12)
+            @test isapprox(xl, xref; rtol = rtol)
+        end
+
+        @testset "preallocated workspace solve $T" for T in (ComplexF32, ComplexF64)
+            rtol = T == ComplexF32 ? sqrt(eps(Float32)) : 1e-9
+            n = 22
+            Acsc = SparseMatrixCSC{T,Int64}(sprandn(T, n, n, 0.3) + n * I)
+            f = AA.AAFactorization(Acsc); AA.factor!(f)
+            B = randn(T, n, 3)
+            Xref = Matrix(Acsc) \ B
+            ws = Vector{UInt8}(undef, AA.solve_workspace_size(f, 3))
+            X = similar(B)
+            AA.solve!(f, B, X, ws)
+            @test isapprox(X, Xref; rtol = rtol)
+            xb = copy(B)
+            AA.solve!(f, xb, ws)                    # in-place
+            @test isapprox(xb, Xref; rtol = rtol)
+        end
+
+        @testset "subfactor R/Q from QR $T" for T in (ComplexF32, ComplexF64)
+            tol = T == ComplexF32 ? 1e-3 : 1e-8
+            m, n = 36, 14
+            A = sprandn(T, m, n, 0.3)
+            while rank(Matrix(A)) < n
+                A = sprandn(T, m, n, 0.3)
+            end
+            f = AA.AAFactorization(SparseMatrixCSC{T,Int64}(A))
+            AA.factor!(f, AA.SparseFactorizationQR)
+            R = AA.subfactor(f, AA.SparseSubfactorR)
+            y = randn(T, n)
+            @test isapprox(R * (R \ y), y; rtol = tol)
+            Q = AA.subfactor(f, AA.SparseSubfactorQ)
+            v = randn(T, n)
+            Qv = Q * v
+            @test length(Qv) == m
+            @test isapprox(norm(Qv), norm(v); rtol = tol)   # Q is an isometry
+            @test isapprox(Q \ Qv, v; rtol = tol)           # Qᴴ Q = I on the range
+        end
+
+        @testset "partial LU update $T" for T in (ComplexF32, ComplexF64)
+            tol = T == ComplexF32 ? 1e-3 : 1e-8
+            n = 16
+            Acsc = SparseMatrixCSC{T,Int64}(sprandn(T, n, n, 0.3) + n * I)
+            f = AA.AAFactorization(Acsc)
+            AA.factor!(f, AA.SparseFactorizationLUUnpivoted)
+            Anew = copy(Acsc)
+            upd = Tuple{Int,Int}[]
+            for j in 1:n, k in Anew.colptr[j]:(Anew.colptr[j+1]-1)
+                if length(upd) < 4
+                    Anew.nzval[k] += T(0.75) + T(0.25)im
+                    push!(upd, (Anew.rowval[k], j))
+                end
+            end
+            AA.update_partial_lu!(f, upd, AASparseMatrix(Anew))
+            b = randn(T, n)
+            @test isapprox(AA.solve(f, b), Matrix(Anew) \ b; rtol = tol)
+        end
+
+        @testset "numeric_options $T" for T in (ComplexF32, ComplexF64)
+            Acsc = SparseMatrixCSC{T,Int64}(sprandn(T, 10, 10, 0.4) + 10I)
+            f = AA.AAFactorization(Acsc); AA.factor!(f)
+            no = AA.numeric_options(f)
+            @test no isa AA.SparseNumericFactorOptions
+            @test no.pivotTolerance > 0
+        end
+
+        @testset "guards" begin
+            n = 10
+            A = AASparseMatrix(SparseMatrixCSC{ComplexF64,Int64}(sprandn(ComplexF64, n, n, 0.3) + n * I))
+            @test_throws DimensionMismatch AA.solve(A, rand(ComplexF64, n + 1); method = :cg)
+            @test_throws ArgumentError AA.solve(A, rand(ComplexF64, n); method = :bogus)
+            @test_throws ArgumentError AA.AAPreconditioner(A; kind = :bogus)
+        end
+    end
 end


### PR DESCRIPTION
Extends the sparse solver surface to **complex** element types (`ComplexF32`/`ComplexF64`), completing Sparse coverage (real support landed in #199). Widens the existing method signatures/type parameters — no new public names.

## Now accepts complex
- COO constructor `AASparseMatrix(I, J, V, m, n)` (complex `SparseConvertFromCoord` bindings).
- Iterative solvers `solve(A, b; method = :cg | :gmres | :lsmr)` — `:cg` requires Hermitian positive-definite; GMRES/LSMR general.
- Preconditioners `AAPreconditioner` (`:diagonal`/`:diagscaling`).
- Preallocated-workspace `solve!(f, b, x, ws)` / `solve!(f, xb, ws)`.
- Sub-factors `subfactor`, `sub * x`, `sub \ b`.
- Partial-LU update `update_partial_lu!`, and `numeric_options` introspection.
- (Hermitian Cholesky/LDLT/LU/QR direct factorizations, `solve`, `SparseMultiply`, `transpose`/`adjoint` already carried complex.)

## ABI notes (verified against the raw layer)
The opaque option/handle structs (`SparseOpaquePreconditioner`, `SparseOpaqueSubfactor`, `SparseOpaqueFactorization`) are phantom-typed on `T` — every field is a pointer/int, so `{ComplexF32}` and `{Float32}` share layout; widening the type parameter is ABI-safe. Complex COO uses the plain `SparseAttributes_t` (the 3-bit Hermitian kind fits the same word) with the value pointer mangled as C `_Complex` (`PKCf`/`PKCd`), which shifts the trailing `void*` reuse to `S5_`. Sub-factor complex apply uses `S0_` for the repeated `DenseMatrix_Complex_*` operand.

## Tests
New guarded `@testset "Complex extended surface"` cross-validating both `ComplexF32` (rtol=sqrt(eps(Float32))) and `ComplexF64` against dense `\`/`LinearAlgebra`: COO round-trip, Hermitian-PD Cholesky + CG (+ diagonal preconditioner), non-Hermitian LU + GMRES (discriminating `A != A'`), rectangular QR + LSMR, workspace solve (multi-RHS + in-place), sub-factor R/Q, complex partial-LU update, `numeric_options`, and guards. `Sparse Linear Algebra`: 627/627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2BF1smS9ip9uAqb8cTqW3