### PR TITLE
skill: PR/docs hygiene notes for the accelerate-wrapper recipe

### DIFF
--- a/.claude/skills/accelerate-wrapper/SKILL.md
+++ b/.claude/skills/accelerate-wrapper/SKILL.md
@@ -201,6 +201,20 @@ the `@docs` block, and ideally a runnable `@example`. New capability area → ne
 rely on (`I = [...]` shadows `LinearAlgebra.I`). Keep README headline claims in sync
 with `benchmarks.md`.
 
+**ALWAYS build the docs locally before pushing — `julia --project=docs docs/make.jl` — and
+confirm it exits 0.** The Documentation build is a **separate CI gate from `Pkg.test()`**:
+a green test suite says nothing about the docs, and a docs failure blocks the PR. The most
+common failure (it has bitten multiple PRs) is Documenter's `cross_references` check:
+**every name you `@ref` must also appear in an `@docs` block**, or the build aborts with
+`Cannot resolve @ref for ...`. That includes refs in a page's cross-ref *table*, refs inside
+a **docstring's own body** (e.g. a "See also [`foo!`](@ref)" line — `foo!` must be `@docs`'d
+too), and functions that share a docstring via `@doc (@doc x) y` (both `x` and `y` need
+their own `@docs` entry to be linkable). `@example`/`jldoctest` blocks are also *executed*
+during the build, so a runtime error or a wrong expected output fails it. When you add a new
+page, wire it into `docs/make.jl` AND make sure every `@ref` it introduces resolves — a
+subagent that "didn't build docs" is the usual cause of a red Documentation check on an
+otherwise-green PR.
+
 ## Phase 6 — Benchmark
 
 Add cases to the matching `test/bench/bench_*.jl` (or a new one, registered in

--- a/.claude/skills/accelerate-wrapper/SKILL.md
+++ b/.claude/skills/accelerate-wrapper/SKILL.md
@@ -216,6 +216,12 @@ and both names of a shared `@doc (@doc x) y`. `@example`/doctest blocks also *ru
 the build. "Didn't build docs" is the usual cause of a red Documentation check on a
 green-tests PR.
 
+**Keep the PR description in sync with all its commits.** When a PR grows past its first
+commit — a follow-up fix, or a later commit that *removes* something an earlier one added —
+update the PR title/body to describe the net final state, not just the opening commit.
+Reviewers read the description, not the commit-by-commit diff; a stale one (e.g. still
+advertising code a later commit deleted) misleads. List the commits' net effect.
+
 ## Phase 6 — Benchmark
 
 Add cases to the matching `test/bench/bench_*.jl` (or a new one, registered in

--- a/.claude/skills/accelerate-wrapper/SKILL.md
+++ b/.claude/skills/accelerate-wrapper/SKILL.md
@@ -96,6 +96,17 @@ surface and what users reach for — not everything that exists. Register-width 
 (rationale in `vmath.jl` `VMATH_COVERAGE`); document any such intentional exclusion
 so the next person doesn't re-investigate it.
 
+**Do NOT wrap deprecated API.** Check each candidate's availability attribute in the SDK
+header (`__API_DEPRECATED(...)`, `API_DEPRECATED`, "deprecated" in the doc comment) and
+skip anything Apple has retired — wrapping it just to pad a coverage number is a net
+negative: it adds maintenance burden against something Apple is removing and steers users
+onto the wrong path. Wrap the **modern replacement** instead (e.g. the whole `BNNSFilter*`
+layer create/apply API is deprecated as of macOS 15 in favor of the **BNNS Graph** API — wrap
+Graph, not the legacy filters; the CoreGraphics/CoreVideo-interop vImage functions similarly).
+When you compute a coverage %, measure it against the *worth-wrapping* surface (excluding
+deprecated + design-excluded families), and state that denominator — don't let a raw
+symbol count pressure you into shipping deprecated wrappers.
+
 ## Phase 2 — Generate / extend the FFI bindings
 
 The symbol is usually already generated. Regenerate only when it's genuinely absent

--- a/.claude/skills/accelerate-wrapper/SKILL.md
+++ b/.claude/skills/accelerate-wrapper/SKILL.md
@@ -96,16 +96,12 @@ surface and what users reach for — not everything that exists. Register-width 
 (rationale in `vmath.jl` `VMATH_COVERAGE`); document any such intentional exclusion
 so the next person doesn't re-investigate it.
 
-**Do NOT wrap deprecated API.** Check each candidate's availability attribute in the SDK
-header (`__API_DEPRECATED(...)`, `API_DEPRECATED`, "deprecated" in the doc comment) and
-skip anything Apple has retired — wrapping it just to pad a coverage number is a net
-negative: it adds maintenance burden against something Apple is removing and steers users
-onto the wrong path. Wrap the **modern replacement** instead (e.g. the whole `BNNSFilter*`
-layer create/apply API is deprecated as of macOS 15 in favor of the **BNNS Graph** API — wrap
-Graph, not the legacy filters; the CoreGraphics/CoreVideo-interop vImage functions similarly).
-When you compute a coverage %, measure it against the *worth-wrapping* surface (excluding
-deprecated + design-excluded families), and state that denominator — don't let a raw
-symbol count pressure you into shipping deprecated wrappers.
+**Do NOT wrap deprecated API.** Check the SDK header's availability attribute
+(`__API_DEPRECATED`, "deprecated" in the doc comment) and skip what Apple retired — wrap the
+**modern replacement** instead (e.g. the `BNNSFilter*` layer API is deprecated in macOS 15
+for the **BNNS Graph** API — wrap Graph). Measure coverage % against the *worth-wrapping*
+surface (excluding deprecated + design-excluded), and state that denominator; don't ship
+deprecated wrappers to pad a symbol count.
 
 ## Phase 2 — Generate / extend the FFI bindings
 
@@ -212,19 +208,13 @@ the `@docs` block, and ideally a runnable `@example`. New capability area → ne
 rely on (`I = [...]` shadows `LinearAlgebra.I`). Keep README headline claims in sync
 with `benchmarks.md`.
 
-**ALWAYS build the docs locally before pushing — `julia --project=docs docs/make.jl` — and
-confirm it exits 0.** The Documentation build is a **separate CI gate from `Pkg.test()`**:
-a green test suite says nothing about the docs, and a docs failure blocks the PR. The most
-common failure (it has bitten multiple PRs) is Documenter's `cross_references` check:
-**every name you `@ref` must also appear in an `@docs` block**, or the build aborts with
-`Cannot resolve @ref for ...`. That includes refs in a page's cross-ref *table*, refs inside
-a **docstring's own body** (e.g. a "See also [`foo!`](@ref)" line — `foo!` must be `@docs`'d
-too), and functions that share a docstring via `@doc (@doc x) y` (both `x` and `y` need
-their own `@docs` entry to be linkable). `@example`/`jldoctest` blocks are also *executed*
-during the build, so a runtime error or a wrong expected output fails it. When you add a new
-page, wire it into `docs/make.jl` AND make sure every `@ref` it introduces resolves — a
-subagent that "didn't build docs" is the usual cause of a red Documentation check on an
-otherwise-green PR.
+**ALWAYS build docs locally before pushing (`julia --project=docs docs/make.jl`, exit 0).**
+It's a **separate CI gate from `Pkg.test()`** — a green suite says nothing about docs. The
+usual failure: Documenter's `cross_references` check aborts unless **every `@ref`'d name is
+also in an `@docs` block** — including refs in a docstring body ("See also [`foo!`](@ref)")
+and both names of a shared `@doc (@doc x) y`. `@example`/doctest blocks also *run* during
+the build. "Didn't build docs" is the usual cause of a red Documentation check on a
+green-tests PR.
 
 ## Phase 6 — Benchmark
 

--- a/.claude/skills/accelerate-wrapper/SKILL.md
+++ b/.claude/skills/accelerate-wrapper/SKILL.md
@@ -246,7 +246,17 @@ julia --project=test/bench test/bench/run_benchmarks.jl [fft|sparse|dense|array]
 julia --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'  # once
 julia --project=docs docs/make.jl                                  # runs @example + doctests
 julia --project=gen  gen/generate.jl                               # only when the raw layer must change
+# ALSO test on the MINIMUM Julia in [compat] (`julia = "1.10"` today) before pushing:
+julia +1.10 --project=. -e 'using Pkg; Pkg.instantiate(); using AppleAccelerate'  # precompile check (min)
 ```
+
+**Always test on the minimum Julia declared in `Project.toml` `[compat]`, not just the one
+on your PATH.** Code that precompiles/runs on a newer Julia can fail on the floor — e.g. a
+runtime-`Symbol` `cglobal` is accepted on ≥1.11 but Julia 1.10 rejects it at precompile
+("first argument not a valid constant expression"; use `Libdl.dlsym` for a run-time name).
+`juliaup` makes this one command (`julia +<min>`); at minimum precompile-load, ideally run
+the changed subsystem's tests. CI's `Julia min` job catches it — running it locally first
+avoids a red round-trip on an otherwise-green PR.
 
 ## Reference
 


### PR DESCRIPTION
Adds a few hygiene notes to the `accelerate-wrapper` skill, learned from this batch of coverage work.

## Commits
1. **Doctest / docs gate** — always build docs locally (`julia --project=docs docs/make.jl`); it's a separate CI gate from `Pkg.test()`, and its usual failure is an `@ref` not listed in an `@docs` block (the failure that hit #198 and #202).
2. **Don't wrap deprecated API** — check the SDK header's availability attribute and wrap the modern replacement instead (e.g. BNNS Graph, not the deprecated `BNNSFilter*` layers); measure coverage % against the worth-wrapping surface.
3. **Tighten** both notes (~20 fewer lines) to keep the skill's context footprint down.
4. **Keep the PR description in sync with all its commits** — when a PR grows past its first commit (a follow-up fix, or a later commit that removes what an earlier one added), update the title/body to the net final state.
5. **Test on the minimum Julia in `[compat]`** — add a `julia +<min>` precompile check to the Verify commands; code that works on a newer Julia can fail on the floor (e.g. runtime-`Symbol` `cglobal` on Julia ≤1.10).

Net effect: the skill's Phase-1 (deprecated-API) and Phase-5 (docs + PR hygiene) guidance is sharper, and slightly shorter overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2BF1smS9ip9uAqb8cTqW3
