### PR TITLE
bnns: remove Apple-deprecated BNNS APIs (and fix stale docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,13 @@ As = AppleAccelerate.AASparseMatrix(SparseMatrixCSC{Float64,Int64}(S))
 xs = AppleAccelerate.solve(AppleAccelerate.cholesky(As), randn(500))
 ```
 
-### Neural-network primitives (BNNS) — a tiny 2-layer MLP forward pass
+### Neural-network primitives (BNNS) — reductions & top-k
 
 ```julia
 using AppleAccelerate
-W1, b1 = randn(Float32, 16, 8), randn(Float32, 16)   # layer 1: 8 → 16
-W2, b2 = randn(Float32, 4, 16), randn(Float32, 4)    # layer 2: 16 → 4
-x = randn(Float32, 8)
-h = AppleAccelerate.bnns_activation(:relu, AppleAccelerate.bnns_matmul(W1, reshape(x, :, 1)) .+ b1)
-logits = AppleAccelerate.bnns_matmul(W2, h) .+ b2     # 4-class output
+logits = randn(Float32, 4, 6)                                 # 4 classes × 6 samples
+sums      = AppleAccelerate.bnns_reduce(:sum, logits; dim = 1)  # column-wise reduction
+vals, idx = AppleAccelerate.bnns_topk(logits, 2; dim = 1)       # top-2 classes per sample
 ```
 
 ### Image processing (vImage)

--- a/docs/src/bnns.md
+++ b/docs/src/bnns.md
@@ -2,12 +2,15 @@
 
 AppleAccelerate wraps a broad slice of Apple's
 [BNNS (Basic Neural Network Subroutines)](https://developer.apple.com/documentation/accelerate/bnns)
-library — around 90% of the ~136 `BNNS*` C entry points. The wrappers are
-**`Float32`-centric**, matching BNNS's native precision for inference. Numerically
-verified helpers (tensor ops, reductions, clipping, random generation, nearest
-neighbors, the fully-connected layer, the optimizer step) are cross-checked here
-against plain-Julia references; the remaining thin wrappers expose the rest of the
-surface with exact FFI signatures for callers who need them.
+library — 83 of the ~136 `BNNS*` C entry points. Most of what is left unwrapped is
+the **deprecated** classic filter/layer construction API (superseded by the Graph
+API, see the deprecation note below); of the modern, non-deprecated surface roughly
+90% is covered. The wrappers are **`Float32`-centric**, matching BNNS's native
+precision for inference. Numerically verified helpers (matrix multiply, activations,
+tensor ops, reductions, clipping, random generation, nearest neighbors, the
+optimizer step) are cross-checked here against plain-Julia references; the remaining
+thin wrappers expose the rest of the surface with exact FFI signatures for callers
+who need them.
 
 ```@setup bnns
 using AppleAccelerate
@@ -200,11 +203,21 @@ AppleAccelerate.bnns_optimizer_step_sgd!
 
 ## What's left to the raw layer
 
-A handful of exotic, training-only entry points are left to the raw
-`AppleAccelerate.LibAccelerate` layer: multi-head attention
-(`BNNSApplyMultiheadAttention` and its backward), the LSTM training-cache path,
-the two-input / fused / loss backward variants, and the fully-connected
-sparsification helpers (`BNNSNDArrayFullyConnectedSparsifySparse{COO,CSR}`).
-These need training caches or opaque multi-kilobyte parameter blocks that cannot
-be validated generically.
+Two groups of entry points are left to the raw `AppleAccelerate.LibAccelerate`
+layer:
+
+- **The deprecated classic filter/layer API** — the `BNNSFilterCreate*` /
+  `BNNSFilterCreateLayer*` constructors and their `*FilterApply*` /
+  `BNNSFusedFilterApply*` execute paths (including the two-input / fused / loss /
+  normalization / pooling / permute batch variants). This is the largest unwrapped
+  block; it is superseded by the BNNS Graph API (above) and is intentionally
+  not given an idiomatic wrapper.
+- **Exotic, training-only entry points** that need training caches or opaque
+  multi-kilobyte parameter blocks that cannot be validated generically: multi-head
+  attention (`BNNSApplyMultiheadAttention` and its backward), the LSTM
+  training-cache path (`BNNSComputeLSTMTrainingCacheCapacity`,
+  `BNNSDirectApplyLSTMBatchTrainingCaching` / `…Backward`),
+  `BNNSComputeNormBackward`, image crop/resize (`BNNSCropResize` /
+  `BNNSCropResizeBackward`), and the fully-connected sparsification helpers
+  (`BNNSNDArrayFullyConnectedSparsifySparse{COO,CSR}`).
 ```

--- a/docs/src/bnns.md
+++ b/docs/src/bnns.md
@@ -1,16 +1,17 @@
 # Neural Network Primitives (BNNS)
 
-AppleAccelerate wraps a broad slice of Apple's
+AppleAccelerate wraps the **current, non-deprecated** slice of Apple's
 [BNNS (Basic Neural Network Subroutines)](https://developer.apple.com/documentation/accelerate/bnns)
-library — 83 of the ~136 `BNNS*` C entry points. Most of what is left unwrapped is
-the **deprecated** classic filter/layer construction API (superseded by the Graph
-API, see the deprecation note below); of the modern, non-deprecated surface roughly
-90% is covered. The wrappers are **`Float32`-centric**, matching BNNS's native
-precision for inference. Numerically verified helpers (matrix multiply, activations,
-tensor ops, reductions, clipping, random generation, nearest neighbors, the
-optimizer step) are cross-checked here against plain-Julia references; the remaining
-thin wrappers expose the rest of the surface with exact FFI signatures for callers
-who need them.
+library — 61 of the ~136 `BNNS*` C entry points. The bulk of the remainder are
+APIs Apple **deprecated in macOS 15 / iOS 18**: the classic filter/layer
+construction API and the deprecated classic + DirectApply tensor kernels
+(`BNNSMatMul`, `BNNSTile`, `BNNSGather`/`BNNSScatter`, the clip / norm family,
+`BNNSOptimizerStep`, …). Those are intentionally **not wrapped** — target the
+**BNNS Graph API** instead. The wrappers are **`Float32`-centric**, matching
+BNNS's native precision for inference. Numerically verified helpers (transpose,
+copy, reductions, top-k, random generation, nearest neighbors) are cross-checked
+here against plain-Julia references; the remaining thin wrappers expose the rest
+of the current surface with exact FFI signatures for callers who need them.
 
 ```@setup bnns
 using AppleAccelerate
@@ -18,13 +19,15 @@ using AppleAccelerate
 
 !!! note "Namespace"
     These functions are not exported. Access them via the `AppleAccelerate.`
-    prefix (e.g. `AppleAccelerate.bnns_matmul`).
+    prefix (e.g. `AppleAccelerate.bnns_reduce`).
 
-!!! warning "Deprecation"
-    Apple deprecated the classic BNNS filter/layer API (macOS 15 / iOS 18) in
-    favour of the newer **BNNS Graph API** ([`BNNSGraph`](@ref AppleAccelerate.BNNSGraph)).
-    The layer wrappers below still work but emit C-level deprecation warnings;
-    new code should target the Graph API.
+!!! warning "Deprecated APIs are excluded"
+    Apple deprecated the classic BNNS filter/layer API and much of the classic
+    tensor/DirectApply surface (macOS 15 / iOS 18) in favour of the newer
+    **BNNS Graph API** ([`BNNSGraph`](@ref AppleAccelerate.BNNSGraph)). This
+    package does **not** wrap any of those deprecated entry points; use the Graph
+    API for that functionality. The "What's left to the raw layer" section below
+    lists the full excluded set.
 
 ## Descriptors
 
@@ -38,95 +41,32 @@ dimension `k+1`** (axis 0 is the contiguous/fastest axis).
 AppleAccelerate.BNNSArray
 ```
 
-## Matrix multiply
-
-[`bnns_matmul`](@ref AppleAccelerate.bnns_matmul) computes `alpha * (A * B)` via
-`BNNSMatMul`. `A` is `m×k`, `B` is `k×n`, and the result is `m×n`. The in-place
-variant [`bnns_matmul!`](@ref AppleAccelerate.bnns_matmul!) writes into a
-preallocated `C`.
-
-```@example bnns
-A = rand(Float32, 4, 3)
-B = rand(Float32, 3, 5)
-
-C = AppleAccelerate.bnns_matmul(A, B)          # == A * B
-C2 = AppleAccelerate.bnns_matmul(A, B; alpha = 2.0f0)  # == 2 .* (A * B)
-
-@assert C  ≈ A * B
-@assert C2 ≈ 2 .* (A * B)
-nothing # hide
-```
-
-```@docs
-AppleAccelerate.bnns_matmul
-AppleAccelerate.bnns_matmul!
-```
-
-## Activations
-
-[`bnns_activation`](@ref AppleAccelerate.bnns_activation) applies a pointwise
-activation to a `Float32` array, returning a new array;
-[`bnns_activation!`](@ref AppleAccelerate.bnns_activation!) writes into a
-preallocated output. Supported functions are `:identity`, `:relu`, `:sigmoid`,
-`:tanh`, and `:abs`.
-
-```@example bnns
-x = Float32[-2, -1, 0, 1, 2]
-y = AppleAccelerate.bnns_activation(:sigmoid, x)
-@assert y ≈ 1f0 ./ (1f0 .+ exp.(-x))
-nothing # hide
-```
-
-```@docs
-AppleAccelerate.bnns_activation
-AppleAccelerate.bnns_activation!
-```
-
 ## Tensor manipulation
 
-Stateless tensor ops, cross-validated against `repeat`, `permutedims`, `tril`/
-`triu`, indexing and broadcast comparisons.
+Stateless tensor ops that remain current, cross-validated against `permutedims`
+and plain copies.
 
 | Function | Meaning |
 |----------|---------|
-| [`bnns_tile`](@ref AppleAccelerate.bnns_tile) / [`bnns_tile_backward`](@ref AppleAccelerate.bnns_tile_backward) | `repeat` and its adjoint |
 | [`bnns_transpose`](@ref AppleAccelerate.bnns_transpose) | swap two axes |
-| [`bnns_compare`](@ref AppleAccelerate.bnns_compare) | element-wise relational op → `Bool` |
-| [`bnns_band_part`](@ref AppleAccelerate.bnns_band_part) | keep a diagonal band (`tril`/`triu`) |
-| [`bnns_gather`](@ref AppleAccelerate.bnns_gather) / [`bnns_scatter`](@ref AppleAccelerate.bnns_scatter) | gather/scatter along an axis |
-| [`bnns_gather_nd`](@ref AppleAccelerate.bnns_gather_nd) / [`bnns_scatter_nd`](@ref AppleAccelerate.bnns_scatter_nd) | N-D coordinate gather/scatter |
-| [`bnns_shuffle`](@ref AppleAccelerate.bnns_shuffle) | pixel / depth shuffle (NCHW) |
 | [`bnns_copy!`](@ref AppleAccelerate.bnns_copy!) | copy with BNNS layout rules |
 
 ```@example bnns
 M = Float32[1 2 3; 4 5 6]
-@assert AppleAccelerate.bnns_tile(M, (2, 1)) == repeat(M, 2, 1)
-@assert AppleAccelerate.bnns_band_part(M[:, 1:2], -1, 0) == [1f0 0; 4 5]  # tril
+@assert AppleAccelerate.bnns_transpose(M, 1, 2) == permutedims(M, (2, 1))
+@assert AppleAccelerate.bnns_copy!(zeros(Float32, 2, 3), M) == M
 nothing # hide
 ```
 
 ```@docs
-AppleAccelerate.bnns_tile
-AppleAccelerate.bnns_tile_backward
 AppleAccelerate.bnns_transpose
-AppleAccelerate.bnns_compare
-AppleAccelerate.bnns_band_part
-AppleAccelerate.bnns_gather
-AppleAccelerate.bnns_scatter
-AppleAccelerate.bnns_gather_nd
-AppleAccelerate.bnns_scatter_nd
-AppleAccelerate.bnns_shuffle
 AppleAccelerate.bnns_copy!
 ```
 
-## Reductions, norms and clipping
+## Reductions
 
 ```@docs
 AppleAccelerate.bnns_reduce
-AppleAccelerate.bnns_compute_norm
-AppleAccelerate.bnns_clip_by_value
-AppleAccelerate.bnns_clip_by_norm
-AppleAccelerate.bnns_clip_by_global_norm
 ```
 
 ## DirectApply kernels
@@ -134,11 +74,8 @@ AppleAccelerate.bnns_clip_by_global_norm
 Fused kernels that run without an explicit filter handle.
 
 ```@docs
-AppleAccelerate.bnns_broadcast_matmul
 AppleAccelerate.bnns_topk
 AppleAccelerate.bnns_in_topk
-AppleAccelerate.bnns_activation_batch!
-AppleAccelerate.bnns_quantizer!
 ```
 
 ## Utility queries
@@ -195,23 +132,22 @@ The compile-options accessors
 introspection helpers (`bnns_graph_input_count`, `bnns_graph_argument_names`,
 `bnns_graph_argument_intents`, …) round out the family.
 
-## Optimizer
-
-```@docs
-AppleAccelerate.bnns_optimizer_step_sgd!
-```
-
 ## What's left to the raw layer
 
-Two groups of entry points are left to the raw `AppleAccelerate.LibAccelerate`
-layer:
+Everything not wrapped above is reachable through the raw
+`AppleAccelerate.LibAccelerate` layer. It falls into three groups:
 
+- **Deprecated classic tensor / DirectApply kernels** (macOS 15 / iOS 18) —
+  `BNNSMatMul`, the activation-filter path, `BNNSTile`/`BNNSTileBackward`,
+  `BNNSCompareTensor`, `BNNSBandPart`, `BNNSGather`/`BNNSScatter` (and their ND
+  forms), `BNNSShuffle`, the clip family (`BNNSClipByValue`/`…ByNorm`/
+  `…ByGlobalNorm`), `BNNSComputeNorm`, `BNNSOptimizerStep`, and the
+  `BNNSDirectApply{ActivationBatch,BroadcastMatMul,Quantizer}` kernels.
+  Superseded by the BNNS Graph API; intentionally not given an idiomatic wrapper.
 - **The deprecated classic filter/layer API** — the `BNNSFilterCreate*` /
   `BNNSFilterCreateLayer*` constructors and their `*FilterApply*` /
   `BNNSFusedFilterApply*` execute paths (including the two-input / fused / loss /
-  normalization / pooling / permute batch variants). This is the largest unwrapped
-  block; it is superseded by the BNNS Graph API (above) and is intentionally
-  not given an idiomatic wrapper.
+  normalization / pooling / permute batch variants).
 - **Exotic, training-only entry points** that need training caches or opaque
   multi-kilobyte parameter blocks that cannot be validated generically: multi-head
   attention (`BNNSApplyMultiheadAttention` and its backward), the LSTM
@@ -220,4 +156,3 @@ layer:
   `BNNSComputeNormBackward`, image crop/resize (`BNNSCropResize` /
   `BNNSCropResizeBackward`), and the fully-connected sparsification helpers
   (`BNNSNDArrayFullyConnectedSparsifySparse{COO,CSR}`).
-```

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -19,7 +19,7 @@ AppleAccelerate is built in two layers:
   offset and enum value in sync with the SDK automatically.
 
 - **Idiomatic layer — the hand-written `src/*.jl` files.** These provide the
-  ergonomic Julia API (`AppleAccelerate.exp`, `integrate`, `bnns_matmul`,
+  ergonomic Julia API (`AppleAccelerate.exp`, `integrate`, `bnns_reduce`,
   `AASparseMatrix`, …). They own the niceties — Julia functions, keyword options,
   tidy return values, broadcasting — and call into `LibAccelerate` for the actual
   ABI work, never naming a C field offset or enum integer themselves.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,15 +92,13 @@ xs = AppleAccelerate.solve(AppleAccelerate.cholesky(As), randn(500))
 nothing # hide
 ```
 
-### Neural-network primitives — a tiny 2-layer MLP (BNNS)
+### Neural-network primitives — reductions & top-k (BNNS)
 
 ```@example quickstart-bnns
 using AppleAccelerate
-W1, b1 = randn(Float32, 16, 8), randn(Float32, 16)   # layer 1: 8 → 16
-W2, b2 = randn(Float32, 4, 16), randn(Float32, 4)    # layer 2: 16 → 4
-x = randn(Float32, 8)
-h = AppleAccelerate.bnns_activation(:relu, AppleAccelerate.bnns_matmul(W1, reshape(x, :, 1)) .+ b1)
-logits = AppleAccelerate.bnns_matmul(W2, h) .+ b2     # 4-class output
+logits = randn(Float32, 4, 6)                                 # 4 classes × 6 samples
+sums      = AppleAccelerate.bnns_reduce(:sum, logits; dim = 1)  # column-wise reduction
+vals, idx = AppleAccelerate.bnns_topk(logits, 2; dim = 1)       # top-2 classes per sample
 nothing # hide
 ```
 

--- a/src/bnns.jl
+++ b/src/bnns.jl
@@ -1,38 +1,27 @@
 # BNNS (Basic Neural Network Subroutines) idiomatic wrappers.
 #
-# This module wraps a broad slice (~90%) of Apple's BNNS API exposed by the raw
-# `LibAccelerate` layer — tensor ops, reductions/clipping, random generation,
-# nearest neighbors, the whole BNNS Graph compiler pipeline, the classic layer
-# filters, and the optimizer step. The numerically important helpers are
-# cross-validated against plain-Julia references; the deprecated layer-create /
-# gradient wrappers are thin passthroughs over the raw parameter structs.
+# This module wraps the Apple-CURRENT (non-deprecated) slice of BNNS exposed by
+# the raw `LibAccelerate` layer: dense array descriptors (`BNNSArray`), the
+# stateless tensor ops that remain current (`bnns_transpose`, `bnns_copy!`), the
+# DirectApply reduction / top-k kernels (`bnns_reduce`, `bnns_topk`,
+# `bnns_in_topk`), random generation, nearest neighbors, layout/size queries, and
+# the full BNNS Graph compiler pipeline. The numerically important helpers are
+# cross-validated against plain-Julia references.
 #
-# A handful of exotic, training-only entry points are left to the raw layer:
-# multi-head attention (forward+backward), the LSTM training-cache path, the
-# two-input/fused/loss backward variants, and the fully-connected sparsification
-# helpers. They need training caches or opaque multi-kilobyte parameter blocks
-# that cannot be validated generically.
-#
-# NOTE: The legacy per-filter layer create/apply API (`BNNSFilter*`) is DEPRECATED by
-# Apple as of macOS 15.0 / iOS 18.0 and is intentionally NOT wrapped here — target the
-# BNNS Graph API (below) instead. The pre-existing `bnns_matmul` / `bnns_activation`
-# convenience helpers still call deprecated BNNS primitives internally and may emit
-# C-level deprecation warnings; the descriptor, tensor-op, reduction, DirectApply,
-# random, optimizer, nearest-neighbor, and Graph wrappers here are current API.
+# NOTE: Every classic and DirectApply BNNS entry point that Apple DEPRECATED in
+# macOS 15.0 / iOS 18.0 is intentionally NOT wrapped here — target the BNNS Graph
+# API (below) instead. That excluded set includes `BNNSMatMul`, `BNNSTile`,
+# `BNNSGather`/`BNNSScatter` (and their ND forms), `BNNSCompareTensor`,
+# `BNNSBandPart`, `BNNSShuffle`, the clip / `BNNSComputeNorm` family,
+# `BNNSOptimizerStep`, the `BNNSDirectApply{ActivationBatch,BroadcastMatMul,
+# Quantizer}` kernels, and the whole `BNNSFilter*` layer create/apply API.
 #
 # Apple docs: https://developer.apple.com/documentation/accelerate/bnns
 
 using .LibAccelerate:
     BNNSNDArrayDescriptor, BNNSDataType, BNNSDataLayout,
     BNNSDataTypeFloat32, BNNSDataTypeInt32,
-    BNNSDataLayoutVector, BNNSDataLayoutColumnMajorMatrix,
-    BNNSActivation, BNNSActivationFunction,
-    BNNSActivationFunctionIdentity, BNNSActivationFunctionRectifiedLinear,
-    BNNSActivationFunctionSigmoid, BNNSActivationFunctionTanh,
-    BNNSActivationFunctionAbs,
-    BNNSLayerParametersActivation, BNNSFilterParameters,
-    BNNSFilterCreateLayerActivation, BNNSFilterApply, BNNSFilterDestroy,
-    BNNSMatMul, BNNSMatMulWorkspaceSize
+    BNNSDataLayoutVector, BNNSDataLayoutColumnMajorMatrix
 
 # Alias the raw layer so the many BNNS enum values, structs and ccall wrappers can
 # be reached without an unwieldy explicit import list. All new wrappers below go
@@ -70,11 +59,6 @@ this constructor reports the array using a column-major-friendly BNNS layout:
 Only `Float32` (and `Int32`) dense, contiguous arrays are supported here; other
 element types or strided/transposed arrays should use the raw `LibAccelerate`
 layer directly.
-
-See also [`bnns_matmul`](@ref), [`bnns_activation`](@ref).
-
-!!! warning
-    Deprecated by Apple (macOS 15+); prefer the BNNS Graph API for new code.
 """
 struct BNNSArray{T,N}
     desc::BNNSNDArrayDescriptor
@@ -116,153 +100,6 @@ function BNNSArray(A::Array{T}) where {T}
         0.0f0,                     # data_bias
     )
     return BNNSArray{T,ndims(A)}(desc, A)
-end
-
-# --- Matrix multiply ---------------------------------------------------------
-
-"""
-    bnns_matmul(A::Matrix{Float32}, B::Matrix{Float32}; alpha = 1.0f0) -> Matrix{Float32}
-
-Compute `alpha * (A * B)` using BNNS (`BNNSMatMul`). `A` is `m×k`, `B` is `k×n`,
-and the result is `m×n`. Equivalent to `alpha .* (A * B)`.
-
-See also [`bnns_matmul!`](@ref).
-
-!!! warning
-    Deprecated by Apple (macOS 15+); prefer the BNNS Graph API for new code.
-"""
-function bnns_matmul(A::AbstractMatrix{BNNSFloat}, B::AbstractMatrix{BNNSFloat};
-                     alpha::Real = 1.0f0)
-    m = size(A, 1)
-    n = size(B, 2)
-    C = Matrix{BNNSFloat}(undef, m, n)
-    return bnns_matmul!(C, A, B; alpha)
-end
-
-"""
-    bnns_matmul!(C, A, B; alpha = 1.0f0) -> C
-
-In-place matrix multiply: `C .= alpha .* (A * B)`. All arguments are `Float32`
-matrices with conforming dimensions. Returns `C`.
-
-!!! warning
-    Deprecated by Apple (macOS 15+); prefer the BNNS Graph API for new code.
-"""
-function bnns_matmul!(C::AbstractMatrix{BNNSFloat}, A::AbstractMatrix{BNNSFloat},
-                      B::AbstractMatrix{BNNSFloat}; alpha::Real = 1.0f0)
-    m, k = size(A)
-    k2, n = size(B)
-    k == k2 || throw(DimensionMismatch("A is $(size(A)), B is $(size(B))"))
-    size(C) == (m, n) || throw(DimensionMismatch("C is $(size(C)), expected ($m, $n)"))
-
-    Ac = A isa Array ? A : Array(A)
-    Bc = B isa Array ? B : Array(B)
-    # BNNSArray requires a dense `Array`; if C is a view (e.g. a batched slice),
-    # compute into a temporary and copy the result back at the end.
-    Cc = C isa Array{BNNSFloat,2} ? C : Matrix{BNNSFloat}(undef, m, n)
-
-    da = BNNSArray(Ac)
-    db = BNNSArray(Bc)
-    dc = BNNSArray(Cc)
-    fp = BNNSFilterParameters(UInt32(0), Csize_t(0), C_NULL, C_NULL)
-
-    GC.@preserve Ac Bc Cc da db dc begin
-        ra = Ref(da.desc); rb = Ref(db.desc); rc = Ref(dc.desc); rfp = Ref(fp)
-        # BNNSMatMul computes out = alpha * inputA * inputB (no transpose).
-        ws = BNNSMatMulWorkspaceSize(false, false, Float32(alpha), ra, rb, rc, rfp)
-        workspace = ws > 0 ? Vector{UInt8}(undef, Int(ws)) : UInt8[]
-        GC.@preserve workspace begin
-            wptr = isempty(workspace) ? C_NULL : pointer(workspace)
-            status = BNNSMatMul(false, false, Float32(alpha), ra, rb, rc, wptr, rfp)
-            status == 0 || error("BNNSMatMul failed with status $status")
-        end
-    end
-    Cc === C || copyto!(C, Cc)
-    return C
-end
-
-# --- Pointwise activation ----------------------------------------------------
-
-"""
-    bnns_activation(f::Symbol, X::AbstractArray{Float32}; alpha=0.0f0, beta=0.0f0) -> AbstractArray{Float32}
-
-Apply a pointwise activation function `f` to every element of `X` using the BNNS
-activation-layer filter API, returning a new array. Supported `f`:
-
-  * `:identity`
-  * `:relu`     — rectified linear
-  * `:sigmoid`
-  * `:tanh`
-  * `:abs`
-
-`alpha`/`beta` are passed to BNNS for activations that take parameters (e.g. leaky
-variants); they are ignored by the activations listed above.
-
-See also [`bnns_activation!`](@ref).
-
-!!! warning
-    Deprecated by Apple (macOS 15+); prefer the BNNS Graph API for new code.
-"""
-function bnns_activation(f::Symbol, X::AbstractArray{BNNSFloat};
-                         alpha::Real = 0.0f0, beta::Real = 0.0f0)
-    Y = similar(Array(X))
-    return bnns_activation!(f, Y, X; alpha, beta)
-end
-
-const _BNNS_ACT = Dict(
-    :identity => BNNSActivationFunctionIdentity,
-    :relu     => BNNSActivationFunctionRectifiedLinear,
-    :sigmoid  => BNNSActivationFunctionSigmoid,
-    :tanh     => BNNSActivationFunctionTanh,
-    :abs      => BNNSActivationFunctionAbs,
-)
-
-"""
-    bnns_activation!(f::Symbol, Y::AbstractArray{Float32}, X::AbstractArray{Float32}; alpha=0.0f0, beta=0.0f0) -> Y
-
-In-place pointwise activation: `Y .= f.(X)`. See [`bnns_activation`](@ref) for the
-list of supported `f`. `X` and `Y` must have the same shape. Returns `Y`.
-
-!!! warning
-    Deprecated by Apple (macOS 15+); prefer the BNNS Graph API for new code.
-"""
-function bnns_activation!(f::Symbol, Y::AbstractArray{BNNSFloat}, X::AbstractArray{BNNSFloat};
-                          alpha::Real = 0.0f0, beta::Real = 0.0f0)
-    size(Y) == size(X) || throw(DimensionMismatch("Y is $(size(Y)), X is $(size(X))"))
-    haskey(_BNNS_ACT, f) ||
-        throw(ArgumentError("BNNS: unsupported activation $(repr(f)); supported: $(sort(collect(keys(_BNNS_ACT))))"))
-
-    # Activation is fully pointwise; treat the data as a flat vector so the
-    # descriptor layout is trivial and identical for any array shape.
-    Xc = X isa Vector ? X : vec(Array(X))
-    Yc = (Y isa Vector) ? Y : Vector{BNNSFloat}(undef, length(Y))
-
-    di = BNNSArray(Xc)
-    do_ = BNNSArray(Yc)
-    act = BNNSActivation(BNNSActivationFunction(_BNNS_ACT[f]),
-                         Float32(alpha), Float32(beta),
-                         Int32(0), Int32(0), Int32(0),
-                         C_NULL, C_NULL, C_NULL)
-    fp = BNNSFilterParameters(UInt32(0), Csize_t(0), C_NULL, C_NULL)
-
-    GC.@preserve Xc Yc di do_ begin
-        lp = BNNSLayerParametersActivation(di.desc, do_.desc, act, UInt32(0))
-        filter = GC.@preserve lp fp begin
-            BNNSFilterCreateLayerActivation(Ref(lp), Ref(fp))
-        end
-        filter == C_NULL && error("BNNSFilterCreateLayerActivation returned NULL")
-        try
-            status = BNNSFilterApply(filter, pointer(Xc), pointer(Yc))
-            status == 0 || error("BNNSFilterApply failed with status $status")
-        finally
-            BNNSFilterDestroy(filter)
-        end
-    end
-
-    if !(Y isa Vector)
-        copyto!(Y, reshape(Yc, size(Y)))
-    end
-    return Y
 end
 
 # =============================================================================
@@ -324,43 +161,6 @@ _bnns_check(status, name) =
 # =============================================================================
 
 """
-    bnns_tile(A::Array, reps) -> Array
-
-Tile `A` by integer repeats `reps` (a tuple/vector, one entry per dimension),
-equivalent to `repeat(A, reps...)`, via `BNNSTile`. `Float32`/integer arrays are
-supported.
-
-!!! warning
-    Deprecated by Apple (macOS 15+); prefer the BNNS Graph API for new code.
-"""
-function bnns_tile(A::Array{T}, reps) where {T}
-    r = ntuple(i -> i <= ndims(A) ? Int(reps[i]) : 1, ndims(A))
-    O = Array{T}(undef, ntuple(i -> size(A, i) * r[i], ndims(A)))
-    di = _desc(A); do_ = _desc(O)
-    GC.@preserve A O begin
-        _bnns_check(LA.BNNSTile(Ref(di), Ref(do_), C_NULL), "BNNSTile")
-    end
-    return O
-end
-
-"""
-    bnns_tile_backward(out_delta::Array, insize) -> Array
-
-Reduce a tiled gradient `out_delta` back to the untiled shape `insize` by summing
-the contributions from each tile, via `BNNSTileBackward`. This is the adjoint of
-[`bnns_tile`](@ref).
-"""
-function bnns_tile_backward(out_delta::Array{T}, insize) where {T}
-    isz = ntuple(i -> Int(insize[i]), ndims(out_delta))
-    ind = Array{T}(undef, isz)
-    di = _desc(ind); do_ = _desc(out_delta)
-    GC.@preserve ind out_delta begin
-        _bnns_check(LA.BNNSTileBackward(Ref(di), Ref(do_), C_NULL), "BNNSTileBackward")
-    end
-    return ind
-end
-
-"""
     bnns_transpose(A::Array, dim0, dim1) -> Array
 
 Swap Julia dimensions `dim0` and `dim1` of `A` (1-based) via `BNNSTranspose`,
@@ -377,80 +177,6 @@ function bnns_transpose(A::Array{T}, dim0::Integer, dim1::Integer) where {T}
     return O
 end
 
-const _BNNS_RELOP = Dict(
-    :(==) => LA.BNNSRelationalOperatorEqual, :eq => LA.BNNSRelationalOperatorEqual,
-    :< => LA.BNNSRelationalOperatorLess, :lt => LA.BNNSRelationalOperatorLess,
-    :<= => LA.BNNSRelationalOperatorLessEqual, :le => LA.BNNSRelationalOperatorLessEqual,
-    :> => LA.BNNSRelationalOperatorGreater, :gt => LA.BNNSRelationalOperatorGreater,
-    :>= => LA.BNNSRelationalOperatorGreaterEqual, :ge => LA.BNNSRelationalOperatorGreaterEqual,
-    :(!=) => LA.BNNSRelationalOperatorNotEqual, :ne => LA.BNNSRelationalOperatorNotEqual,
-)
-
-"""
-    bnns_compare(op::Symbol, A::Array{Float32}, B::Array{Float32}) -> Array{Bool}
-
-Element-wise relational comparison `A op B` via `BNNSCompareTensor`, returning a
-`Bool` array. `op` is one of `:eq (==)`, `:lt (<)`, `:le (<=)`, `:gt (>)`,
-`:ge (>=)`, `:ne (!=)`.
-"""
-function bnns_compare(op::Symbol, A::Array{Float32}, B::Array{Float32})
-    haskey(_BNNS_RELOP, op) ||
-        throw(ArgumentError("BNNS: unsupported comparison $(repr(op))"))
-    size(A) == size(B) || throw(DimensionMismatch("A is $(size(A)), B is $(size(B))"))
-    O = Array{Bool}(undef, size(A))
-    da = _desc(A); db = _desc(B); do_ = _desc(O)
-    GC.@preserve A B O begin
-        _bnns_check(LA.BNNSCompareTensor(Ref(da), Ref(db),
-                    LA.BNNSRelationalOperator(_BNNS_RELOP[op]), Ref(do_)),
-                    "BNNSCompareTensor")
-    end
-    return O
-end
-
-"""
-    bnns_band_part(A::Matrix, num_lower, num_upper) -> Matrix
-
-Keep only the central band of `A` via `BNNSBandPart`: entries more than
-`num_lower` below or `num_upper` above the diagonal (in Julia's column-major
-sense) are zeroed. A negative count keeps the entire lower/upper triangle, so
-`bnns_band_part(A, -1, 0)` is `tril(A)` and `bnns_band_part(A, 0, -1)` is
-`triu(A)`.
-
-!!! note
-    BNNS counts bands in row-major orientation, so the underlying
-    `num_lower`/`num_upper` are swapped internally to give the Julia-native
-    `tril`/`triu` meaning documented here.
-"""
-function bnns_band_part(A::Array{T}, num_lower::Integer, num_upper::Integer) where {T}
-    O = similar(A)
-    di = _desc(A); do_ = _desc(O)
-    # BNNS band orientation is row-major (transposed vs Julia col-major): pass the
-    # counts swapped so callers get the intuitive tril/triu semantics.
-    GC.@preserve A O begin
-        _bnns_check(LA.BNNSBandPart(Cint(num_upper), Cint(num_lower),
-                    Ref(di), Ref(do_), C_NULL), "BNNSBandPart")
-    end
-    return O
-end
-
-"""
-    bnns_gather(dim::Integer, input::Array, indices::Array{Int32}) -> Array
-
-Gather slices of `input` along Julia dimension `dim` using 0-based `indices`
-(as BNNS/C expects) via `BNNSGather`, i.e. `selectdim(input, dim, indices.+1)`
-stacked along `dim`. `indices` is a 1-D `Int32` vector.
-"""
-function bnns_gather(dim::Integer, input::Array{T}, indices::Array{Int32}) where {T}
-    osz = collect(size(input)); osz[dim] = length(indices)
-    O = Array{T}(undef, osz...)
-    di = _desc(input); dind = _desc(indices); do_ = _desc(O)
-    GC.@preserve input indices O begin
-        _bnns_check(LA.BNNSGather(Csize_t(dim - 1), Ref(di), Ref(dind), Ref(do_), C_NULL),
-                    "BNNSGather")
-    end
-    return O
-end
-
 const _BNNS_REDUCE = Dict(
     :max => LA.BNNSReduceFunctionMax, :min => LA.BNNSReduceFunctionMin,
     :sum => LA.BNNSReduceFunctionSum, :mean => LA.BNNSReduceFunctionMean,
@@ -458,80 +184,6 @@ const _BNNS_REDUCE = Dict(
     :l2 => LA.BNNSReduceFunctionL2Norm, :product => LA.BNNSReduceFunctionProduct,
     :logsumexp => LA.BNNSReduceFunctionLogSumExp,
 )
-
-"""
-    bnns_scatter(dim::Integer, op::Symbol, input::Array, indices::Array{Int32}, output::Array) -> output
-
-Scatter `input` into a copy of `output` along Julia dimension `dim` at 0-based
-`indices`, combining collisions with reduce `op` (`:sum`, `:max`, `:min`, ...)
-via `BNNSScatter`. `output` is updated in place and returned.
-"""
-function bnns_scatter(dim::Integer, op::Symbol, input::Array{T},
-                      indices::Array{Int32}, output::Array{T}) where {T}
-    haskey(_BNNS_REDUCE, op) || throw(ArgumentError("BNNS: unsupported reduce $(repr(op))"))
-    di = _desc(input); dind = _desc(indices); do_ = _desc(output)
-    GC.@preserve input indices output begin
-        _bnns_check(LA.BNNSScatter(Csize_t(dim - 1), LA.BNNSReduceFunction(_BNNS_REDUCE[op]),
-                    Ref(di), Ref(dind), Ref(do_), C_NULL), "BNNSScatter")
-    end
-    return output
-end
-
-"""
-    bnns_gather_nd(input::Array, indices::Array{Int32}, output::Array) -> output
-
-N-dimensional gather (`BNNSGatherND`): `indices` holds coordinate vectors along
-its first (fastest) axis and `output` collects `input[coord...]`. Thin wrapper —
-supply pre-shaped descriptors' backing arrays; `output` is filled and returned.
-"""
-function bnns_gather_nd(input::Array{T}, indices::Array{Int32}, output::Array{T}) where {T}
-    di = _desc(input); dind = _desc(indices); do_ = _desc(output)
-    GC.@preserve input indices output begin
-        _bnns_check(LA.BNNSGatherND(Ref(di), Ref(dind), Ref(do_), C_NULL), "BNNSGatherND")
-    end
-    return output
-end
-
-"""
-    bnns_scatter_nd(op::Symbol, input::Array, indices::Array{Int32}, output::Array) -> output
-
-N-dimensional scatter (`BNNSScatterND`), the adjoint of [`bnns_gather_nd`](@ref),
-combining collisions with reduce `op`. `output` is updated in place and returned.
-"""
-function bnns_scatter_nd(op::Symbol, input::Array{T}, indices::Array{Int32},
-                         output::Array{T}) where {T}
-    haskey(_BNNS_REDUCE, op) || throw(ArgumentError("BNNS: unsupported reduce $(repr(op))"))
-    di = _desc(input); dind = _desc(indices); do_ = _desc(output)
-    GC.@preserve input indices output begin
-        _bnns_check(LA.BNNSScatterND(LA.BNNSReduceFunction(_BNNS_REDUCE[op]),
-                    Ref(di), Ref(dind), Ref(do_), C_NULL), "BNNSScatterND")
-    end
-    return output
-end
-
-const _BNNS_SHUFFLE = Dict(
-    :pixel_shuffle => LA.BNNSShuffleTypePixelShuffleNCHW,
-    :pixel_unshuffle => LA.BNNSShuffleTypePixelUnshuffleNCHW,
-    :depth_to_space => LA.BNNSShuffleTypeDepthToSpaceNCHW,
-    :space_to_depth => LA.BNNSShuffleTypeSpaceToDepthNCHW,
-)
-
-"""
-    bnns_shuffle(type::Symbol, input::Array, output::Array) -> output
-
-Pixel / depth shuffle (`BNNSShuffle`). `type` is one of `:pixel_shuffle`,
-`:pixel_unshuffle`, `:depth_to_space`, `:space_to_depth` (all NCHW). `output`
-must be pre-sized for the transform and is returned.
-"""
-function bnns_shuffle(type::Symbol, input::Array{T}, output::Array{T}) where {T}
-    haskey(_BNNS_SHUFFLE, type) || throw(ArgumentError("BNNS: unsupported shuffle $(repr(type))"))
-    di = _desc(input); do_ = _desc(output)
-    GC.@preserve input output begin
-        _bnns_check(LA.BNNSShuffle(LA.BNNSShuffleType(_BNNS_SHUFFLE[type]),
-                    Ref(di), Ref(do_), C_NULL), "BNNSShuffle")
-    end
-    return output
-end
 
 """
     bnns_copy!(dest::Array, src::Array) -> dest
@@ -543,89 +195,6 @@ function bnns_copy!(dest::Array{T}, src::Array{T}) where {T}
     ds = _desc(src); dd = _desc(dest)
     GC.@preserve src dest begin
         _bnns_check(LA.BNNSCopy(Ref(dd), Ref(ds), C_NULL), "BNNSCopy")
-    end
-    return dest
-end
-
-# =============================================================================
-# Clipping / norm (stateless kernels)
-# =============================================================================
-
-"""
-    bnns_clip_by_value(src::Array{Float32}, lo, hi) -> Array{Float32}
-
-Element-wise clamp to `[lo, hi]` via `BNNSClipByValue` (`≡ clamp.(src, lo, hi)`).
-"""
-function bnns_clip_by_value(src::Array{Float32}, lo::Real, hi::Real)
-    dest = similar(src)
-    ds = _desc(src); dd = _desc(dest)
-    GC.@preserve src dest begin
-        _bnns_check(LA.BNNSClipByValue(Ref(dd), Ref(ds), Float32(lo), Float32(hi)),
-                    "BNNSClipByValue")
-    end
-    return dest
-end
-
-"""
-    bnns_clip_by_norm(src::Array{Float32}, max_norm; axis_flags=0) -> Array{Float32}
-
-Scale `src` down so its L2 norm does not exceed `max_norm` via `BNNSClipByNorm`
-(`axis_flags` selects the reduction axes as a bitmask; `0` = whole tensor).
-"""
-function bnns_clip_by_norm(src::Array{Float32}, max_norm::Real; axis_flags::Integer = 0)
-    dest = similar(src)
-    ds = _desc(src); dd = _desc(dest)
-    GC.@preserve src dest begin
-        _bnns_check(LA.BNNSClipByNorm(Ref(dd), Ref(ds), Float32(max_norm), UInt32(axis_flags)),
-                    "BNNSClipByNorm")
-    end
-    return dest
-end
-
-"""
-    bnns_clip_by_global_norm(srcs::Vector{<:Array{Float32}}, max_norm; use_norm=0) -> Vector{Array{Float32}}
-
-Rescale a collection of tensors by a single global-norm factor via
-`BNNSClipByGlobalNorm`. When `use_norm <= 0` the global norm is computed from
-`srcs`; otherwise the supplied `use_norm` is used. Returns freshly-allocated
-clipped copies.
-"""
-function bnns_clip_by_global_norm(srcs::Vector{<:Array{Float32}}, max_norm::Real;
-                                  use_norm::Real = 0)
-    n = length(srcs)
-    dests = [similar(s) for s in srcs]
-    sdescs = [Ref(_desc(s)) for s in srcs]
-    ddescs = [Ref(_desc(d)) for d in dests]
-    GC.@preserve srcs dests sdescs ddescs begin
-        sptrs = [Base.unsafe_convert(Ptr{BNNSNDArrayDescriptor}, r) for r in sdescs]
-        dptrs = [Base.unsafe_convert(Ptr{BNNSNDArrayDescriptor}, r) for r in ddescs]
-        GC.@preserve sptrs dptrs begin
-            _bnns_check(LA.BNNSClipByGlobalNorm(pointer(dptrs), pointer(sptrs),
-                        Csize_t(n), Float32(max_norm), Float32(use_norm)),
-                        "BNNSClipByGlobalNorm")
-        end
-    end
-    return dests
-end
-
-"""
-    bnns_compute_norm(src::Array{Float32}; axis_flags=0) -> Array{Float32}
-
-L2 norm reduction over the axes selected by the `axis_flags` bitmask via
-`BNNSComputeNorm` (`axis_flags = 0` reduces the whole tensor to a scalar). The
-reduced axes collapse to length 1 in the returned array.
-"""
-function bnns_compute_norm(src::Array{Float32}; axis_flags::Integer = 0)
-    if axis_flags == 0
-        dest = zeros(Float32, ntuple(_ -> 1, ndims(src)))
-    else
-        osz = ntuple(i -> (axis_flags & (1 << (i - 1))) != 0 ? 1 : size(src, i), ndims(src))
-        dest = zeros(Float32, osz)
-    end
-    ds = _desc(src); dd = _desc(dest)
-    GC.@preserve src dest begin
-        _bnns_check(LA.BNNSComputeNorm(Ref(dd), Ref(ds),
-                    LA.BNNSNormType(LA.BNNSL2Norm), UInt32(axis_flags)), "BNNSComputeNorm")
     end
     return dest
 end
@@ -675,29 +244,6 @@ end
 # =============================================================================
 # DirectApply family (stateless kernels operating on descriptors)
 # =============================================================================
-
-"""
-    bnns_broadcast_matmul(A, B; transA=false, transB=false, alpha=1f0) -> Array{Float32}
-
-Batched / broadcasting matrix multiply `alpha * A * B` via
-`BNNSDirectApplyBroadcastMatMul`. For 2-D inputs this equals
-`alpha .* (A * B)`; higher-rank inputs multiply the trailing two axes and
-broadcast the batch axes.
-"""
-function bnns_broadcast_matmul(A::Array{Float32}, B::Array{Float32};
-                               transA::Bool = false, transB::Bool = false,
-                               alpha::Real = 1.0f0)
-    m = transA ? size(A, 2) : size(A, 1)
-    n = transB ? size(B, 1) : size(B, 2)
-    batch = ntuple(i -> max(size(A, i + 2), size(B, i + 2)), max(ndims(A), ndims(B)) - 2)
-    O = Array{Float32}(undef, m, n, batch...)
-    da = _desc(A); db = _desc(B); do_ = _desc(O)
-    GC.@preserve A B O begin
-        LA.BNNSDirectApplyBroadcastMatMul(transA, transB, Float32(alpha),
-            Ref(da), Ref(db), Ref(do_), C_NULL)
-    end
-    return O
-end
 
 """
     bnns_topk(input::Array{Float32}, K; dim=1) -> (values, indices)
@@ -1296,106 +842,3 @@ function bnns_in_topk(input::Array{Float32}, targets::Array{Int32}, K::Integer; 
     end
     return out
 end
-
-# Activation-struct helper shared by the DirectApply activation kernel.
-_default_fp() = LA.BNNSFilterParameters(UInt32(0), Csize_t(0), C_NULL, C_NULL)
-const _BNNS_ACT_ALL = Dict(
-    :identity => LA.BNNSActivationFunctionIdentity,
-    :relu => LA.BNNSActivationFunctionRectifiedLinear,
-    :sigmoid => LA.BNNSActivationFunctionSigmoid,
-    :tanh => LA.BNNSActivationFunctionTanh,
-    :abs => LA.BNNSActivationFunctionAbs,
-    :gelu => LA.BNNSActivationFunctionGELU,
-    :softmax => LA.BNNSActivationFunctionSoftmax,
-)
-function _activation_struct(f::Symbol; alpha = 0.0f0, beta = 0.0f0)
-    haskey(_BNNS_ACT_ALL, f) || throw(ArgumentError("BNNS: unsupported activation $(repr(f))"))
-    LA.BNNSActivation(BNNSActivationFunction(_BNNS_ACT_ALL[f]), Float32(alpha), Float32(beta),
-                      Int32(0), Int32(0), Int32(0), C_NULL, C_NULL, C_NULL)
-end
-
-"""
-    bnns_activation_batch!(func::Symbol, out::Array{Float32}, inp::Array{Float32}; alpha=0f0, beta=0f0) -> out
-
-Apply a pointwise activation over a batch directly (`BNNSDirectApplyActivationBatch`),
-without an explicit filter handle. `func` is any activation supported by
-[`bnns_activation`](@ref) (`:identity`, `:relu`, `:sigmoid`, `:tanh`, `:abs`).
-"""
-function bnns_activation_batch!(func::Symbol, out::Array{Float32}, inp::Array{Float32};
-                                alpha = 0.0f0, beta = 0.0f0)
-    di = _desc(inp); do_ = _desc(out)
-    act = _activation_struct(func; alpha, beta)
-    lp = Ref(LA.BNNSLayerParametersActivation(di, do_, act, UInt32(0)))
-    fp = Ref(_default_fp())
-    GC.@preserve inp out lp fp begin
-        _bnns_check(LA.BNNSDirectApplyActivationBatch(
-            Base.unsafe_convert(Ptr{LA.BNNSLayerParametersActivation}, lp),
-            Base.unsafe_convert(Ptr{LA.BNNSFilterParameters}, fp),
-            Csize_t(1), Csize_t(0), Csize_t(0)), "BNNSDirectApplyActivationBatch")
-    end
-    return out
-end
-
-const _QUANT_FN = Dict(:quantize => LA.BNNSQuantizerFunctionQuantize,
-                       :dequantize => LA.BNNSQuantizerFunctionDequantize)
-
-"""
-    bnns_quantizer!(func::Symbol, out::Array, inp::Array, scale::Array{Float32}, bias::Array{Float32}; axis_mask=0) -> out
-
-Quantize or dequantize `in` into `out` with per-`axis_mask` `scale`/`bias`
-(`BNNSDirectApplyQuantizer`). `func` is `:quantize` or `:dequantize`.
-"""
-function bnns_quantizer!(func::Symbol, out::Array, inp::Array, scale::Array{Float32},
-                         bias::Array{Float32}; axis_mask::Integer = 0)
-    haskey(_QUANT_FN, func) || throw(ArgumentError("BNNS: func must be :quantize/:dequantize"))
-    di = _desc(inp); do_ = _desc(out); ds = _desc(scale); db = _desc(bias)
-    lp = Ref(LA.BNNSLayerParametersQuantization(Csize_t(axis_mask),
-        LA.BNNSQuantizerFunction(_QUANT_FN[func]), di, do_, ds, db))
-    fp = Ref(_default_fp())
-    GC.@preserve inp out scale bias lp fp begin
-        _bnns_check(LA.BNNSDirectApplyQuantizer(
-            Base.unsafe_convert(Ptr{LA.BNNSLayerParametersQuantization}, lp),
-            Base.unsafe_convert(Ptr{LA.BNNSFilterParameters}, fp),
-            Csize_t(1), Csize_t(0), Csize_t(0)), "BNNSDirectApplyQuantizer")
-    end
-    return out
-end
-
-# =============================================================================
-# Optimizer step (stateless kernel over parameter/gradient/accumulator lists)
-# =============================================================================
-
-"""
-    bnns_optimizer_step_sgd!(params, grads, accumulators, fields::BNNSOptimizerSGDMomentumFields) -> params
-
-Apply one SGD-with-momentum update (`BNNSOptimizerStep`,
-`BNNSOptimizerFunctionSGDMomentum`) across the parallel lists of parameter,
-gradient and momentum-accumulator `Array{Float32}`s, updating each in place.
-`fields` is a raw `LibAccelerate.BNNSOptimizerSGDMomentumFields`.
-"""
-function bnns_optimizer_step_sgd!(params::Vector{<:Array{Float32}},
-                                  grads::Vector{<:Array{Float32}},
-                                  accumulators::Vector{<:Array{Float32}},
-                                  fields::LA.BNNSOptimizerSGDMomentumFields)
-    n = length(params)
-    (length(grads) == n && length(accumulators) == n) ||
-        throw(DimensionMismatch("params/grads/accumulators length mismatch"))
-    pd = [Ref(_desc(x)) for x in params]
-    gd = [Ref(_desc(x)) for x in grads]
-    ad = [Ref(_desc(x)) for x in accumulators]
-    fr = Ref(fields); fp = Ref(_default_fp())
-    GC.@preserve params grads accumulators pd gd ad fr fp begin
-        pp = [Base.unsafe_convert(Ptr{BNNSNDArrayDescriptor}, r) for r in pd]
-        gp = [Base.unsafe_convert(Ptr{BNNSNDArrayDescriptor}, r) for r in gd]
-        ap = [Base.unsafe_convert(Ptr{BNNSNDArrayDescriptor}, r) for r in ad]
-        GC.@preserve pp gp ap begin
-            _bnns_check(LA.BNNSOptimizerStep(
-                LA.BNNSOptimizerFunction(LA.BNNSOptimizerFunctionSGDMomentum),
-                Ptr{Cvoid}(Base.unsafe_convert(Ptr{LA.BNNSOptimizerSGDMomentumFields}, fr)),
-                Csize_t(n), pointer(pp), pointer(gp), pointer(ap),
-                Base.unsafe_convert(Ptr{LA.BNNSFilterParameters}, fp)), "BNNSOptimizerStep")
-        end
-    end
-    return params
-end
-

--- a/test/bnns_tests.jl
+++ b/test/bnns_tests.jl
@@ -1,107 +1,11 @@
 using AppleAccelerate
-using AppleAccelerate: BNNSArray, bnns_matmul, bnns_matmul!, bnns_activation, bnns_activation!,
-                      bnns_data_type
-using LinearAlgebra
+using AppleAccelerate: BNNSArray, bnns_data_type
 using Statistics
 using Test
 
 const AA = AppleAccelerate
 
 @testset "BNNS core" begin
-    @testset "matmul" begin
-        for (m, k, n) in ((4, 3, 5), (1, 1, 1), (8, 8, 8), (10, 1, 7), (2, 6, 3))
-            A = randn(Float32, m, k)
-            B = randn(Float32, k, n)
-            ref = A * B
-            C = bnns_matmul(A, B)
-            @test size(C) == (m, n)
-            @test C ≈ ref atol=1f-4 rtol=1f-4
-
-            # alpha scaling
-            @test bnns_matmul(A, B; alpha = 2.5f0) ≈ 2.5f0 .* ref atol=1f-4 rtol=1f-4
-
-            # in-place
-            Cout = Matrix{Float32}(undef, m, n)
-            @test bnns_matmul!(Cout, A, B) === Cout
-            @test Cout ≈ ref atol=1f-4 rtol=1f-4
-        end
-
-        # dimension checks
-        @test_throws DimensionMismatch bnns_matmul!(zeros(Float32, 2, 2),
-                                                    randn(Float32, 2, 3), randn(Float32, 4, 2))
-        @test_throws DimensionMismatch bnns_matmul!(zeros(Float32, 3, 3),
-                                                    randn(Float32, 2, 3), randn(Float32, 3, 2))
-
-        # Non-Array (strided/transposed) inputs go through the `Array(A)` copy
-        # path inside bnns_matmul!.
-        let Al = randn(Float32, 4, 3), Bl = randn(Float32, 4, 5)
-            @test bnns_matmul(transpose(Al), Bl) ≈ transpose(Al) * Bl atol = 1f-4 rtol = 1f-4
-            adj = adjoint(randn(Float32, 3, 6))   # 6×3 adjoint wrapper
-            Bk = randn(Float32, 3, 2)
-            @test bnns_matmul(adj, Bk) ≈ adj * Bk atol = 1f-4 rtol = 1f-4
-            @test bnns_matmul(adj, Bk) isa Matrix{Float32}
-        end
-
-        # View / transpose destination exercises the temp-buffer copy-back path
-        # (Cc !== C) in bnns_matmul!.
-        let A = randn(Float32, 4, 3), B = randn(Float32, 3, 5), ref = nothing
-            ref = A * B
-            Cbig = zeros(Float32, 8, 8)
-            Cv = view(Cbig, 1:4, 1:5)
-            @test bnns_matmul!(Cv, A, B) === Cv
-            @test Cv ≈ ref atol = 1f-4 rtol = 1f-4
-            @test all(==(0f0), Cbig[5:8, :])  # untouched region
-
-            sq = randn(Float32, 3, 3)
-            Ct = transpose(zeros(Float32, 3, 3))
-            @test bnns_matmul!(Ct, sq, sq) === Ct
-            @test Ct ≈ sq * sq atol = 1f-4 rtol = 1f-4
-        end
-    end
-
-    @testset "activation" begin
-        X = randn(Float32, 6, 4) .- 0.5f0
-        refs = Dict(
-            :identity => X,
-            :relu     => max.(X, 0f0),
-            :sigmoid  => 1 ./ (1 .+ exp.(-X)),
-            :tanh     => tanh.(X),
-            :abs      => abs.(X),
-        )
-        for (f, ref) in refs
-            Y = bnns_activation(f, X)
-            @test size(Y) == size(X)
-            @test Y ≈ ref atol=1f-5 rtol=1f-5
-
-            # in-place, including non-Vector destination round-trip
-            Yout = similar(X)
-            @test bnns_activation!(f, Yout, X) === Yout
-            @test Yout ≈ ref atol=1f-5 rtol=1f-5
-        end
-
-        # vector input (the trivial-layout fast path)
-        v = randn(Float32, 100) .- 0.5f0
-        @test bnns_activation(:relu, v) ≈ max.(v, 0f0) atol=1f-6
-
-        # In-place aliasing X === Y on a Vector (Yc === Xc, true in-place).
-        let w = randn(Float32, 64) .- 0.5f0, wref = tanh.(copy(w))
-            @test bnns_activation!(:tanh, w, w) === w
-            @test w ≈ wref atol = 1f-5 rtol = 1f-5
-        end
-
-        # Transposed / strided input drives the `vec(Array(X))` copy path.
-        let Xs = (randn(Float32, 5, 7) .- 0.5f0)
-            Xt = transpose(Xs)              # 7×5 lazy transpose
-            @test bnns_activation(:sigmoid, Xt) ≈ (1 ./ (1 .+ exp.(-Xt))) atol = 1f-5 rtol = 1f-5
-            Yt = similar(Array(Xt))
-            @test bnns_activation!(:relu, Yt, Xt) === Yt
-            @test Yt ≈ max.(Array(Xt), 0f0) atol = 1f-6
-        end
-
-        @test_throws ArgumentError bnns_activation(:nope, X)
-        @test_throws DimensionMismatch bnns_activation!(:relu, zeros(Float32, 2), X)
-    end
-
     @testset "BNNSArray descriptor" begin
         A = rand(Float32, 3, 4)
         d = BNNSArray(A)
@@ -134,46 +38,15 @@ end
 
 @testset "BNNS tensor ops" begin
     M = Float32[1 2 3; 4 5 6]
-    @test AA.bnns_tile(M, (2, 1)) == repeat(M, 2, 1)
-    @test AA.bnns_tile(M, (1, 3)) == repeat(M, 1, 3)
-    @test AA.bnns_tile(M, (2, 2)) == repeat(M, 2, 2)
-    @test AA.bnns_tile_backward(repeat(M, 2, 3), (2, 3)) ≈ 6 .* M
-
     @test AA.bnns_transpose(M, 1, 2) == permutedims(M, (2, 1))
     C = Float32[1 2; 3 4; 5 6]
     @test AA.bnns_transpose(C, 1, 2) == permutedims(C, (2, 1))
 
-    X = Float32[1 5; 3 2]; Y = Float32[2 5; 1 4]
-    @test AA.bnns_compare(:lt, X, Y) == (X .< Y)
-    @test AA.bnns_compare(:eq, X, Y) == (X .== Y)
-    @test AA.bnns_compare(:ge, X, Y) == (X .>= Y)
-    @test AA.bnns_compare(:ne, X, Y) == (X .!= Y)
-    @test AA.bnns_compare(:lt, X, Y) isa Array{Bool}
-    @test_throws ArgumentError AA.bnns_compare(:bogus, X, Y)
-    @test_throws DimensionMismatch AA.bnns_compare(:lt, X, Float32[1 2 3])
-
-    S = Float32[1 2 3; 4 5 6; 7 8 9]
-    @test AA.bnns_band_part(S, -1, 0) == tril(S)
-    @test AA.bnns_band_part(S, 0, -1) == triu(S)
-    @test AA.bnns_band_part(S, 0, 0) == Float32.(diagm(diag(S)))
-
     G = Float32[1 2 3; 4 5 6]
-    idx = Int32[2, 0]
-    @test AA.bnns_gather(2, G, idx) == G[:, idx .+ 1]
-    idx2 = Int32[1, 0]
-    @test AA.bnns_gather(1, G, idx2) == G[idx2 .+ 1, :]
-
-    # scatter rows into a zeroed output
-    out = zeros(Float32, 3, 2); inp = Float32[10 20; 30 40]; sidx = Int32[0, 2]
-    ref = zeros(Float32, 3, 2); ref[1, :] = inp[1, :]; ref[3, :] = inp[2, :]
-    @test AA.bnns_scatter(1, :sum, inp, sidx, out) == ref
-    @test out === AA.bnns_scatter(1, :sum, inp, sidx, out) |> (_ -> out)  # in place
-    @test_throws ArgumentError AA.bnns_scatter(1, :bogus, inp, sidx, zeros(Float32, 3, 2))
-
     @test AA.bnns_copy!(zeros(Float32, 2, 3), G) == G
 end
 
-@testset "BNNS reductions / norms / clipping" begin
+@testset "BNNS reductions" begin
     G = Float32[1 2 3; 4 5 6]
     @test vec(AA.bnns_reduce(:sum, G; dim = 1)) == vec(sum(G, dims = 1))
     @test vec(AA.bnns_reduce(:sum, G; dim = 2)) == vec(sum(G, dims = 2))
@@ -181,24 +54,6 @@ end
     @test vec(AA.bnns_reduce(:min, G; dim = 1)) == vec(minimum(G, dims = 1))
     @test vec(AA.bnns_reduce(:mean, G; dim = 2)) ≈ vec(sum(G, dims = 2) ./ 3)
     @test_throws ArgumentError AA.bnns_reduce(:bogus, G)
-
-    @test AA.bnns_compute_norm(Float32[3, 4])[1] ≈ 5.0f0
-    @test AA.bnns_compute_norm(Float32[5, 12, 0])[1] ≈ 13.0f0
-
-    @test AA.bnns_clip_by_value(Float32[-2, 0.5, 3], 0.0f0, 1.0f0) == Float32[0, 0.5, 1]
-    @test AA.bnns_clip_by_value(Float32[-5, 5], -1.0f0, 1.0f0) == Float32[-1, 1]
-
-    x = Float32[3, 4]
-    @test AA.bnns_clip_by_norm(x, 2.0f0) ≈ x .* (2.0f0 / 5)
-    @test AA.bnns_clip_by_norm(x, 10.0f0) == x           # already within
-    @test norm(AA.bnns_clip_by_norm(x, 2.0f0)) ≈ 2.0f0
-
-    a = Float32[3, 4]; b = Float32[0, 0, 0, 12]   # global norm 13
-    r = AA.bnns_clip_by_global_norm([a, b], 6.5f0)   # factor 0.5
-    @test r[1] ≈ a .* 0.5f0
-    @test r[2] ≈ b .* 0.5f0
-    r2 = AA.bnns_clip_by_global_norm([a, b], 13.0f0) # no clip
-    @test r2[1] ≈ a && r2[2] ≈ b
 end
 
 @testset "BNNS utility queries" begin
@@ -210,10 +65,6 @@ end
 end
 
 @testset "BNNS DirectApply" begin
-    A2 = Float32[1 2; 3 4]; B2 = Float32[1 0; 0 1]
-    @test AA.bnns_broadcast_matmul(A2, B2) ≈ A2 * B2
-    @test AA.bnns_broadcast_matmul(A2, B2; alpha = 2.0f0) ≈ 2.0f0 .* (A2 * B2)
-
     # top-K along dim 1
     T = Float32[1 9; 7 2; 3 5]
     vals, inds = AA.bnns_topk(T, 2; dim = 1)
@@ -296,27 +147,4 @@ end
     @test AA.bnns_compile_options_get_single_thread(o2)
     @test AA.bnns_compile_options_get_optimization(o2) == :ir_size
     @test AA.bnns_compile_options_get_output_fd(o2) == 3
-end
-
-@testset "BNNS activation batch" begin
-    # direct activation batch (BNNSDirectApplyActivationBatch — no filter handle)
-    ob = zeros(Float32, 4)
-    AA.bnns_activation_batch!(:relu, ob, Float32[-1, 2, -3, 4])
-    @test ob == Float32[0, 2, 0, 4]
-    @test_throws ArgumentError AA.bnns_activation_batch!(:bogus, zeros(Float32, 2), Float32[1, 2])
-end
-
-@testset "BNNS optimizer step" begin
-    # SGD without momentum: theta -= lr * (grad * gradient_scale)
-    theta = [Float32[1.0, 2.0, 3.0]]
-    grad = [Float32[0.1, 0.2, 0.3]]
-    accum = [zeros(Float32, 3)]
-    LAcc = AA.LibAccelerate
-    fields = LAcc.BNNSOptimizerSGDMomentumFields(0.5f0, 0.0f0, 1.0f0, 0.0f0, false, 0.0f0, 0.0f0,
-        false, LAcc.BNNSOptimizerRegularizationFunction(LAcc.BNNSOptimizerRegularizationNone),
-        LAcc.BNNSOptimizerSGDMomentumVariant(LAcc.BNNSSGDMomentumVariant0))
-    AA.bnns_optimizer_step_sgd!(theta, grad, accum, fields)
-    @test theta[1] ≈ Float32[1, 2, 3] .- 0.5f0 .* Float32[0.1, 0.2, 0.3]
-    @test_throws DimensionMismatch AA.bnns_optimizer_step_sgd!(theta, grad,
-        [zeros(Float32, 3), zeros(Float32, 3)], fields)
 end

--- a/test/linalg_tests.jl
+++ b/test/linalg_tests.jl
@@ -1,7 +1,7 @@
 # BLAS/LAPACK forwarding requires macOS >= 13.4. This file is the LAST one
 # included by runtests.jl, so on older systems (or when the version can't be
 # determined) we can cleanly `exit(0)` here without skipping any other test files
-# — the non-forwarding suites (quadrature, bnns, nnlib) have already run.
+# — the non-forwarding suites (quadrature, bnns) have already run.
 let v = AppleAccelerate.get_macos_version()
 if v === nothing || v < v"13.4"
     @info("AppleAccelerate.jl needs macOS >= 13.4 for BLAS forwarding. Not testing forwarding capabilities.")


### PR DESCRIPTION
## Summary

Removes every BNNS wrapper that Apple has **deprecated upstream** (macOS 15 / iOS 18), so the package no longer exposes any deprecated Accelerate entry point. Also folds in the smaller docs-accuracy fixes this branch started with.

The deprecated set was determined authoritatively from the SDK headers (`vecLib.framework/Headers/BNNS/bnns.h`) — the `__API_DEPRECATED("Use BNNSGraph* APIs", …)` annotations. Apple's deprecation is **selective**, not "all classic BNNS": e.g. `BNNSMatMul`/`BNNSTile`/`BNNSGather` are deprecated, but `BNNSTranspose`/`BNNSCopy`/`BNNSDirectApplyReduction`/`BNNSDirectApplyTopK`/random/kNN remain current — so only the genuinely-deprecated wrappers were removed.

## Removed (21 idiomatic wrappers + their helpers, tests, docs)

`bnns_matmul(!)`, `bnns_activation(!)`, `bnns_tile`, `bnns_tile_backward`, `bnns_compare`, `bnns_band_part`, `bnns_gather(_nd)`, `bnns_scatter(_nd)`, `bnns_shuffle`, `bnns_clip_by_value`, `bnns_clip_by_norm`, `bnns_clip_by_global_norm`, `bnns_compute_norm`, `bnns_broadcast_matmul`, `bnns_activation_batch!`, `bnns_quantizer!`, `bnns_optimizer_step_sgd!`.

## Kept (still `__API_AVAILABLE` upstream)

`BNNSArray` descriptors, `bnns_transpose`, `bnns_copy!`, `bnns_reduce`, `bnns_topk`, `bnns_in_topk`, random generation, nearest neighbors, layout/size queries, and the full **BNNS Graph API**.

## Also in this PR
- Docs accuracy: BNNS coverage figures corrected and the "what's left to the raw layer" section rewritten to list the excluded deprecated set (now 61/136 wrapped).
- Dropped a stale `nnlib` reference in `test/linalg_tests.jl` (the NNlib extension no longer exists).
- `docs/src/index.md`, `README.md`, `docs/src/extensions.md` examples that used removed wrappers were repointed to kept functions (verified they run).

## Verification
- `using AppleAccelerate` loads clean.
- BNNS test suite: **56 pass / 0 fail** (Julia exit 0).
- No dangling references to any removed name in `src/`, `test/`, or `docs/`.
- All 24 `@docs` entries in `bnns.md` resolve to defined, documented symbols.
- `src/bnns.jl`: 1402 → 846 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)